### PR TITLE
Implement new marker-reference scope "spread-content"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,13 +39,13 @@ javadoc {
 
 repositories {
     mavenCentral()
-    //mavenLocal()
+    mavenLocal()
     //maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {
     provided group: "biz.aQute.bnd", name: "annotation", version: "2.3.0"
-    compile "org.daisy.dotify:dotify.api:2.10.0"
+    compile "org.daisy.dotify:dotify.api:2.10.1-SNAPSHOT"
     compile "org.daisy.dotify:dotify.common:2.1.0"
     compile (group: 'org.daisy.libs', name: 'saxon-he', version: '9.5.1.5') {
 		exclude module: 'Saxon-HE'

--- a/src/org/daisy/dotify/formatter/impl/PageImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/PageImpl.java
@@ -442,7 +442,8 @@ class PageImpl implements Page {
 		} else if (field instanceof MarkerReferenceField) {
 			MarkerReferenceField f2 = (MarkerReferenceField)field;
 			PageImpl start;
-			if (f2.getSearchScope()==MarkerSearchScope.SPREAD) {
+			if (f2.getSearchScope()==MarkerSearchScope.SPREAD ||
+				f2.getSearchScope()==MarkerSearchScope.SPREAD_CONTENT) {
 				start = p.getPageInVolumeWithOffset(f2.getOffset(), p.shouldAdjustOutOfBounds(f2));
 			} else {
 				start = p.getPageInSequenceWithOffset(f2.getOffset(), p.shouldAdjustOutOfBounds(f2));
@@ -479,7 +480,16 @@ class PageImpl implements Page {
 		int index = 0;
 		int count = 0;
 		List<Marker> m;
+		boolean skipLeading = false;
 		if (markerRef.getSearchScope() == MarkerReferenceField.MarkerSearchScope.PAGE_CONTENT) {
+			skipLeading = true;
+		} else if (markerRef.getSearchScope() == MarkerReferenceField.MarkerSearchScope.SPREAD_CONTENT) {
+			PageImpl prevPageInVolume = page.getPageInVolumeWithOffset(-1, false);
+			if (prevPageInVolume == null || !page.isWithinSpreadScope(-1, prevPageInVolume)) {
+				skipLeading = true;
+			}
+		}
+		if (skipLeading) {
 			m = page.getContentMarkers();
 		} else {
 			m = page.getMarkers();
@@ -503,8 +513,11 @@ class PageImpl implements Page {
 			) {
 			next = page.getPageInSequenceWithOffset(dir, false);
 		} //else if (markerRef.getSearchScope() == MarkerSearchScope.SPREAD && page.isWithinDocumentSpreadScope(dir)) {
-			else if (markerRef.getSearchScope() == MarkerSearchScope.SPREAD && page.isWithinVolumeSpreadScope(dir)) {
-			next = page.getPageInVolumeWithOffset(dir, false);
+		  else if (markerRef.getSearchScope() == MarkerSearchScope.SPREAD ||
+		           markerRef.getSearchScope() == MarkerSearchScope.SPREAD_CONTENT) {
+			if (page.isWithinVolumeSpreadScope(dir)) {
+				next = page.getPageInVolumeWithOffset(dir, false);
+			}
 		}
 		if (next!=null) {
 			return findMarker(next, markerRef);
@@ -523,7 +536,7 @@ class PageImpl implements Page {
 				return false;
 			case SEQUENCE: case VOLUME: case DOCUMENT:
 				return true;
-			case SPREAD:
+			case SPREAD_CONTENT: case SPREAD:
 				//return  isWithinSequenceSpreadScope(markerRef.getOffset());				
 				//return  isWithinDocumentSpreadScope(markerRef.getOffset());
 				return isWithinVolumeSpreadScope(markerRef.getOffset());

--- a/test/org/daisy/dotify/engine/impl/MarkerReferenceTest.java
+++ b/test/org/daisy/dotify/engine/impl/MarkerReferenceTest.java
@@ -13,8 +13,18 @@ public class MarkerReferenceTest extends AbstractFormatterEngineTest {
 	}
 	
 	@Test
+	public void testPageContentMarker() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
+		testPEF("resource-files/marker-ref-page-content-input.obfl", "resource-files/marker-ref-page-content-expected.pef", false);
+	}
+	
+	@Test
 	public void testSpreadMarker() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/marker-ref-spread-input.obfl", "resource-files/marker-ref-spread-expected.pef", false);
+	}
+	
+	@Test
+	public void testSpreadContentMarker() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
+		testPEF("resource-files/marker-ref-spread-content-input.obfl", "resource-files/marker-ref-spread-content-expected.pef", false);
 	}
 	
 	@Test

--- a/test/org/daisy/dotify/engine/impl/TakenFromDP2Test.java
+++ b/test/org/daisy/dotify/engine/impl/TakenFromDP2Test.java
@@ -138,7 +138,6 @@ public class TakenFromDP2Test extends AbstractFormatterEngineTest {
 		testPEF("resource-files/dp2/marker-reference-page-forward-backward-input.obfl",
 		        "resource-files/dp2/marker-reference-page-forward-backward-expected.pef", false);
 	}
-	@Ignore // issue https://github.com/joeha480/dotify/issues/150
 	@Test
 	public void testMarkerReferencePageContentForwardBackward() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/dp2/marker-reference-page-content-forward-backward-input.obfl",
@@ -169,14 +168,11 @@ public class TakenFromDP2Test extends AbstractFormatterEngineTest {
 		testPEF("resource-files/dp2/marker-reference-page-first-workaround-input.obfl",
 		        "resource-files/dp2/marker-reference-page-first-workaround-expected.pef", false);
 	}
-	@Ignore // issue https://github.com/joeha480/dotify/issues/150
 	@Test
 	public void testMarkerReferencePageStartWorkaround() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/dp2/marker-reference-page-start-workaround-input.obfl",
 		        "resource-files/dp2/marker-reference-page-start-workaround-expected.pef", true);
 	}
-	@Ignore // issue https://github.com/joeha480/dotify/issues/150
-	        // and no spread-content scope
 	@Test
 	public void testMarkerReferenceSpreadStartWorkaround() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/dp2/marker-reference-spread-start-workaround-input.obfl",

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-page-content-forward-backward-expected.pef
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-page-content-forward-backward-expected.pef
@@ -3,7 +3,7 @@
    <head>
       <meta>
          <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">marker-reference-page-content-forward-backward</dc:title>
-         <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests marker-reference with scope page-content. Tested with both forward and backward direction. Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break. Broken: behavior of page-content changed in Dotify 2.0.0 (see https://github.com/joeha480/dotify/issues/150).</dc:description>
+         <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests marker-reference with scope page-content. Tested with both forward and backward direction. Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break.</dc:description>
          <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
       </meta>
    </head>
@@ -12,14 +12,14 @@
          <section>
             <page>
                <!-- 1 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 1   1 -->
+               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- (empty) -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
             </page>
             <page>
-               <row>⠼⠃⠀⠀⠀⠀⠀⠀⠼⠉</row> <!-- 2   3 --> <!-- or should it be?: 2   2 -->
+               <row>⠼⠃⠀⠀⠀⠀⠀⠀⠼⠉</row> <!-- 2   3 -->
                <row>⠁⠁⠁⠁⠁</row>
                <!-- 2 -->
                <row>⠁⠁⠁⠁⠁</row>
@@ -28,7 +28,7 @@
             <!-- 3 -->
             </page>
             <page>
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- (empty) -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
@@ -36,7 +36,7 @@
             </page>
             <page>
                <!-- 4 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 4   4 -->
+               <row>⠼⠙⠀⠀⠀⠀⠀⠀⠼⠙</row> <!-- 4   4 --> <!-- should ideally be: (empty) -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
@@ -44,13 +44,33 @@
             </page>
             <page>
                <!-- 5 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 5   5 -->
+               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- (empty) -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
             </page>
             <page>
                <!-- 6 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 6   6 -->
+               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- (empty) -->
+               <row>⠁⠁⠁⠁⠁</row>
+               <row>⠁⠁⠁⠁⠁</row>
+            </page>
+            <page>
+               <!-- 7 -->
+               <row>⠼⠛⠀⠀⠀⠀⠀⠀⠼⠛</row> <!-- 7   7 -->
+               <row/>
+               <row>⠁⠁⠁⠁⠁</row>
+               <row>⠁⠁⠁⠁⠁</row>
+            </page>
+            <page>
+               <!-- 8 -->
+               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- (empty) -->
+               <row>⠁⠁⠁⠁⠁</row>
+               <row>⠁⠁⠁⠁⠁</row>
+            </page>
+            <page>
+               <!-- 9 -->
+               <row>⠼⠊⠀⠀⠀⠀⠀⠀⠼⠊</row> <!-- 9   9 -->
+               <row/>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
             </page>

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-page-content-forward-backward-input.obfl
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-page-content-forward-backward-input.obfl
@@ -2,7 +2,7 @@
 <obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="und" hyphenate="false">
    <meta>
       <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">marker-reference-page-content-forward-backward</dc:title>
-      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests marker-reference with scope page-content. Tested with both forward and backward direction. Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break. Broken: behavior of page-content changed in Dotify 2.0.0 (see https://github.com/joeha480/dotify/issues/150).</dc:description>
+      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests marker-reference with scope page-content. Tested with both forward and backward direction. Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break.</dc:description>
    </meta>
    <layout-master name="a" page-width="10" page-height="5" duplex="true" page-number-variable="page">
       <default-template>
@@ -20,7 +20,8 @@
    </layout-master>
    <sequence master="a">
       <!-- new page -->
-      <block><marker class="foo" value="1"/>⠁⠁⠁⠁⠁
+      <block><block><marker class="foo" value="1"/></block>
+                ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
@@ -42,11 +43,30 @@
                 ⠁⠁⠁⠁⠁
               </block>
       <!-- new page -->
-      <block><marker class="foo" value="5"/>⠁⠁⠁⠁⠁
+      <block><block><marker class="foo" value="5"/></block>
+                ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
               </block>
       <!-- new page -->
-      <block break-before="page"><marker class="foo" value="6"/>⠁⠁⠁⠁⠁
+      <block break-before="page"><block><marker class="foo" value="6"/></block>
+                ⠁⠁⠁⠁⠁
+                ⠁⠁⠁⠁⠁
+              </block>
+      <!-- new page -->
+      <block break-before="page" padding-top="1"><block><marker class="foo" value="7"/></block>
+                ⠁⠁⠁⠁⠁
+                ⠁⠁⠁⠁⠁
+              </block>
+      <!-- new page -->
+      <block break-before="page"><block><block><marker class="foo" value="8"/></block>
+                  ⠁⠁⠁⠁⠁
+                </block>
+                ⠁⠁⠁⠁⠁
+              </block>
+      <!-- new page -->
+      <block break-before="page"><block padding-top="1"><block><marker class="foo" value="9"/></block>
+                  ⠁⠁⠁⠁⠁
+                </block>
                 ⠁⠁⠁⠁⠁
               </block>
    </sequence>

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-page-start-workaround-expected.pef
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-page-start-workaround-expected.pef
@@ -3,7 +3,7 @@
    <head>
       <meta>
          <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">marker-reference-page-start-workaround</dc:title>
-         <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests (hypothetical) marker-reference type that corresponds with 'page-start' in CSS. This type is not yet directly supported in OBFL. As a workaround I do a forward page-content search for the marker 'foo/prev' (rendered top left corner), and if that does not return a value, a backward sequence search for the marker 'foo' (top right corner). At any position in the OBFL the value of the preceding marker of class 'foo' matches the value of the following marker of class 'foo/prev'. In addition, tests marker-reference with scope page-content and direction backward, which corresponds with 'page-last-except-start' in CSS (bottom left corner). Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break. Broken: behavior of page-content changed in Dotify 2.0.0 (see https://github.com/joeha480/dotify/issues/150).</dc:description>
+         <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests (hypothetical) marker-reference type that corresponds with 'page-start' in CSS. This type is not directly supported in OBFL. As a workaround I do a forward page search for the marker 'foo/prev' (rendered top left corner), and if that does not return a value, a backward sequence search for the marker 'foo' (top right corner). At any position in the OBFL the value of the preceding marker of class 'foo' matches the value of the following marker of class 'foo/prev'. In addition, tests marker-reference with scope page and direction backward, which corresponds more or less with 'page-last-except-start' in CSS (bottom left corner). Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break.</dc:description>
          <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
       </meta>
    </head>
@@ -17,7 +17,7 @@
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 1 -->
+               <row>⠼⠁⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- 1     -->
             </page>
             <page>
                <row>⠼⠁⠀⠀⠀⠀⠀⠀⠼⠉</row> <!-- 1   3 -->
@@ -39,30 +39,30 @@
             </page>
             <page>
                <!-- 4 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙</row> <!--     4 --> <!-- was: 3   4 -->
+               <row>⠼⠉⠀⠀⠀⠀⠀⠀⠼⠙</row> <!-- 3   4 --> <!-- should ideally be:     4 -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 4 -->
+               <row>⠼⠙⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- 4     -->
             </page>
             <page>
                <!-- 5 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠑</row> <!--     5 --> <!-- was: 4   5 -->
+               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠑</row> <!--     5 -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row/>
                <row/>
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 5 -->
+               <row>⠼⠑⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- 5     -->
             </page>
             <page>
                <!-- 6 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠋</row> <!--     6 --> <!-- was: 5   6 -->
+               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠋</row> <!--     6 -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row/>
                <row/>
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 6 -->
+               <row>⠼⠋⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- 6     -->
             </page>
          </section>
       </volume>

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-page-start-workaround-input.obfl
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-page-start-workaround-input.obfl
@@ -2,7 +2,7 @@
 <obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="und" hyphenate="false">
    <meta>
       <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">marker-reference-page-start-workaround</dc:title>
-      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests (hypothetical) marker-reference type that corresponds with 'page-start' in CSS. This type is not yet directly supported in OBFL. As a workaround I do a forward page-content search for the marker 'foo/prev' (rendered top left corner), and if that does not return a value, a backward sequence search for the marker 'foo' (top right corner). At any position in the OBFL the value of the preceding marker of class 'foo' matches the value of the following marker of class 'foo/prev'. In addition, tests marker-reference with scope page-content and direction backward, which corresponds with 'page-last-except-start' in CSS (bottom left corner). Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break. Broken: behavior of page-content changed in Dotify 2.0.0 (see https://github.com/joeha480/dotify/issues/150).</dc:description>
+      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests (hypothetical) marker-reference type that corresponds with 'page-start' in CSS. This type is not directly supported in OBFL. As a workaround I do a forward page search for the marker 'foo/prev' (rendered top left corner), and if that does not return a value, a backward sequence search for the marker 'foo' (top right corner). At any position in the OBFL the value of the preceding marker of class 'foo' matches the value of the following marker of class 'foo/prev'. In addition, tests marker-reference with scope page and direction backward, which corresponds more or less with 'page-last-except-start' in CSS (bottom left corner). Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break.</dc:description>
    </meta>
    <layout-master name="a" page-width="10" page-height="6" duplex="true" page-number-variable="page">
       <default-template>
@@ -17,7 +17,7 @@
          </header>
          <footer>
             <field>
-               <marker-reference marker="foo" direction="backward" scope="page-content"/>
+               <marker-reference marker="foo" direction="backward" scope="page"/>
             </field>
             <field/>
             <field/>
@@ -26,7 +26,8 @@
    </layout-master>
    <sequence master="a">
       <!-- new page -->
-      <block><marker class="foo/prev" value=""/><marker class="foo" value="1"/>⠁⠁⠁⠁⠁
+      <block><block><marker class="foo" value="1"/></block>
+                ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
@@ -37,9 +38,9 @@
                 ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
-                ​<!-- new page -->
-         <marker class="foo/prev" value="3"/>
+                <marker class="foo/prev" value="3"/>
          <marker class="foo" value="3"/>
+                ​<!-- new page -->
                 ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
@@ -50,11 +51,13 @@
                 ⠁⠁⠁⠁⠁
               </block>
       <!-- new page -->
-      <block><marker class="foo/prev" value="4"/><marker class="foo" value="5"/>⠁⠁⠁⠁⠁
+      <block><block><marker class="foo/prev" value="4"/><marker class="foo" value="5"/></block>
+                ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
               </block>
       <!-- new page -->
-      <block break-before="page"><marker class="foo/prev" value="5"/><marker class="foo" value="6"/>⠁⠁⠁⠁⠁
+      <block break-before="page"><block><marker class="foo/prev" value="5"/><marker class="foo" value="6"/></block>
+                ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
               </block>
    </sequence>

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-spread-start-workaround-expected.pef
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-spread-start-workaround-expected.pef
@@ -3,18 +3,17 @@
    <head>
       <meta>
          <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">marker-reference-spread-start-workaround</dc:title>
-         <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests (hypothetical) marker-reference type that corresponds with 'spread-start' in CSS. This type is not yet directly supported in OBFL. As a workaround I do a forward page-content search for the marker 'foo/prev' starting on the left page (rendered left-aligned on the first header line), and if that does not return a value, a backward sequence search for the marker 'foo' also starting on the left page (right-aligned on first header line). At any position in the OBFL the value of the preceding marker of class 'foo' matches the value of the following marker of class 'foo/prev'. This workaround is problematic for the first page of the document (see https://github.com/joeha480/dotify/issues/144). A better workaround would be to do a forward spread-content search for 'foo/prev' starting on the left page (left-aligned on the second header line), and if that does not return a value, a backward sequence search for the marker 'foo' starting on the right page (right-aligned on the second header line). Unfortunately scope 'spread-content' is not available. In this test I use 'spread' instead. In addition, tests marker-reference with scope spread-content and direction backward, starting on the right page, which corresponds with 'page-last-except-start' in CSS (bottom left corner). Because 'spread-content' is not available I use 'spread' in this test. Everything tested on both left- and right-hand pages. Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break. Broken: behavior of page-content changed in Dotify 2.0.0 (see https://github.com/joeha480/dotify/issues/150).</dc:description>
+         <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests (hypothetical) marker-reference type that corresponds with 'spread-start' in CSS. This type is not directly supported in OBFL. As a workaround I do a forward spread search for the marker 'foo/prev' starting on the left page (rendered top left corner), and if that does not return a value, a backward sequence search for the marker 'foo' starting on the right page (top right corner). At any position in the OBFL the value of the preceding marker of class 'foo' matches the value of the following marker of class 'foo/prev'. In addition, tests marker-reference with scope spread and direction backward, starting on the right page, which corresponds more or less with 'spread-last-except-start' in CSS (bottom left corner). Everything tested on both left- and right-hand pages. Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break.</dc:description>
          <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
       </meta>
    </head>
    <body>
-      <volume cols="10" rows="7" rowgap="0" duplex="true">
+      <volume cols="10" rows="6" rowgap="0" duplex="true">
          <section>
             <!-- right -->
             <page>
                <!-- 0 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
-               <row>⠼⠚⠀⠀⠀⠀⠀⠀⠼⠁</row> <!-- 0    1 --> <!-- was:      1 -->
+               <row>⠼⠚⠀⠀⠀⠀⠀⠀⠼⠁</row> <!-- 0    1 -->
                <row>⠁⠁⠁⠁⠁</row>
                <!-- 1 -->
                <row>⠁⠁⠁⠁⠁</row>
@@ -24,7 +23,6 @@
             </page>
             <!-- left -->
             <page>
-               <row>⠼⠁⠀⠀⠀⠀⠀⠀⠼⠉</row> <!-- 1   3 -->
                <row>⠼⠁⠀⠀⠀⠀⠀⠀⠼⠉</row> <!-- 1   3 -->
                <row>⠁⠁⠁⠁⠁</row>
                <!-- 2 -->
@@ -37,7 +35,6 @@
             <!-- right -->
             <page>
                <row>⠼⠁⠀⠀⠀⠀⠀⠀⠼⠉</row> <!-- 1   3 -->
-               <row>⠼⠁⠀⠀⠀⠀⠀⠀⠼⠉</row> <!-- 1   3 -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
@@ -47,8 +44,7 @@
             <!-- left -->
             <page>
                <!-- 4 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙</row> <!--     4 --> <!-- was: 3   4 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙</row> <!-- 4   5 --> <!-- was: 3   5 -->
+               <row>⠼⠉⠀⠀⠀⠀⠀⠀⠼⠑</row> <!-- 3   5 --> <!-- should ideally be: 4   5 -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
@@ -58,8 +54,7 @@
             <!-- right -->
             <page>
                <!-- 5 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙</row> <!--     4 --> <!-- was: 3   4 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙</row> <!-- 4   5 --> <!-- was: 3   5 -->
+               <row>⠼⠉⠀⠀⠀⠀⠀⠀⠼⠑</row> <!-- 3   5 --> <!-- should ideally be: 4   5 -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row/>
@@ -69,13 +64,12 @@
             <!-- left -->
             <page>
                <!-- 6 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠋</row> <!--     6 --> <!-- was: 5   6 -->
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠋</row> <!--     6 --> <!-- was: 5   6 -->
+               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠼⠋</row> <!--     6 -->
                <row>⠁⠁⠁⠁⠁</row>
                <row>⠁⠁⠁⠁⠁</row>
                <row/>
                <row/>
-               <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- was: 6 -->
+               <row>⠼⠋⠀⠀⠀⠀⠀⠀⠀⠀</row> <!-- 6 -->
             </page>
          </section>
       </volume>

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-spread-start-workaround-input.obfl
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/marker-reference-spread-start-workaround-input.obfl
@@ -2,23 +2,13 @@
 <obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="und" hyphenate="false">
    <meta>
       <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">marker-reference-spread-start-workaround</dc:title>
-      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests (hypothetical) marker-reference type that corresponds with 'spread-start' in CSS. This type is not yet directly supported in OBFL. As a workaround I do a forward page-content search for the marker 'foo/prev' starting on the left page (rendered left-aligned on the first header line), and if that does not return a value, a backward sequence search for the marker 'foo' also starting on the left page (right-aligned on first header line). At any position in the OBFL the value of the preceding marker of class 'foo' matches the value of the following marker of class 'foo/prev'. This workaround is problematic for the first page of the document (see https://github.com/joeha480/dotify/issues/144). A better workaround would be to do a forward spread-content search for 'foo/prev' starting on the left page (left-aligned on the second header line), and if that does not return a value, a backward sequence search for the marker 'foo' starting on the right page (right-aligned on the second header line). Unfortunately scope 'spread-content' is not available. In this test I use 'spread' instead. In addition, tests marker-reference with scope spread-content and direction backward, starting on the right page, which corresponds with 'page-last-except-start' in CSS (bottom left corner). Because 'spread-content' is not available I use 'spread' in this test. Everything tested on both left- and right-hand pages. Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break. Broken: behavior of page-content changed in Dotify 2.0.0 (see https://github.com/joeha480/dotify/issues/150).</dc:description>
+      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests (hypothetical) marker-reference type that corresponds with 'spread-start' in CSS. This type is not directly supported in OBFL. As a workaround I do a forward spread search for the marker 'foo/prev' starting on the left page (rendered top left corner), and if that does not return a value, a backward sequence search for the marker 'foo' starting on the right page (top right corner). At any position in the OBFL the value of the preceding marker of class 'foo' matches the value of the following marker of class 'foo/prev'. In addition, tests marker-reference with scope spread and direction backward, starting on the right page, which corresponds more or less with 'spread-last-except-start' in CSS (bottom left corner). Everything tested on both left- and right-hand pages. Tested with markers at the beginning of the sequence, in the middle of a page, at a soft page break within a block, at a soft page break between two blocks, and at a hard page break.</dc:description>
    </meta>
-   <layout-master name="a" page-width="10" page-height="7" duplex="true" page-number-variable="page">
+   <layout-master name="a" page-width="10" page-height="6" duplex="true" page-number-variable="page">
       <template use-when="(= (% $page 2) 1)">
          <header>
             <field>
-               <marker-reference marker="foo/prev" direction="forward" scope="page-content" start-offset="-1"/>
-            </field>
-            <field/>
-            <field>
-               <marker-reference marker="foo" direction="backward" scope="sequence" start-offset="-1"/>
-            </field>
-         </header>
-         <header>
-            <field>
-               <!-- spread-content does not exist so using spread -->
-               <marker-reference marker="foo/prev" direction="forward" scope="spread" start-offset="-1"/>
+               <marker-reference marker="foo/prev" direction="forward" scope="spread-content" start-offset="-1"/>
             </field>
             <field/>
             <field>
@@ -27,7 +17,6 @@
          </header>
          <footer>
             <field>
-               <!-- spread-content does not exist so using spread -->
                <marker-reference marker="foo" direction="backward" scope="spread"/>
             </field>
             <field/>
@@ -37,17 +26,7 @@
       <template use-when="(= (% $page 2) 0)">
          <header>
             <field>
-               <marker-reference marker="foo/prev" direction="forward" scope="page-content"/>
-            </field>
-            <field/>
-            <field>
-               <marker-reference marker="foo" direction="backward" scope="sequence"/>
-            </field>
-         </header>
-         <header>
-            <field>
-               <!-- spread-content does not exist so using spread -->
-               <marker-reference marker="foo/prev" direction="forward" scope="spread"/>
+               <marker-reference marker="foo/prev" direction="forward" scope="spread-content"/>
             </field>
             <field/>
             <field>
@@ -56,7 +35,6 @@
          </header>
          <footer>
             <field>
-               <!-- spread-content does not exist so using spread -->
                <marker-reference marker="foo" direction="backward" scope="spread" start-offset="1"/>
             </field>
             <field/>
@@ -70,7 +48,8 @@
    </layout-master>
    <sequence master="a">
       <!-- right page -->
-      <block><marker class="foo/prev" value=""/><marker class="foo" value="0"/>⠁⠁⠁⠁⠁
+      <block><block><marker class="foo" value="0"/></block>
+                ⠁⠁⠁⠁⠁
                 <marker class="foo/prev" value="0"/>
          <marker class="foo" value="1"/>
                 ⠁⠁⠁⠁⠁
@@ -96,11 +75,13 @@
                 ⠁⠁⠁⠁⠁
               </block>
       <!-- right page -->
-      <block><marker class="foo/prev" value="4"/><marker class="foo" value="5"/>⠁⠁⠁⠁⠁
+      <block><block><marker class="foo/prev" value="4"/><marker class="foo" value="5"/></block>
+                ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
               </block>
       <!-- left page -->
-      <block break-before="page"><marker class="foo/prev" value="5"/><marker class="foo" value="6"/>⠁⠁⠁⠁⠁
+      <block break-before="page"><block><marker class="foo/prev" value="5"/><marker class="foo" value="6"/></block>
+                ⠁⠁⠁⠁⠁
                 ⠁⠁⠁⠁⠁
               </block>
    </sequence>

--- a/test/org/daisy/dotify/engine/impl/resource-files/marker-ref-page-content-expected.pef
+++ b/test/org/daisy/dotify/engine/impl/resource-files/marker-ref-page-content-expected.pef
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pef version="2008-1" xmlns="http://www.daisy.org/ns/2008/pef">
+<head>
+<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:format>application/x-pef+xml</dc:format>
+<dc:identifier>identifier?</dc:identifier>
+<dc:date>2015-10-21</dc:date>
+<dc:title>Marker reference search test</dc:title>
+<dc:description>Tests marker references within a page.</dc:description>
+</meta>
+</head>
+<body>
+<volume cols="20" rows="6" rowgap="0" duplex="true">
+<section>
+<page>
+<row>⠼⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙</row>
+<row>⠤⠤⠤⠤</row>
+</page>
+</section>
+</volume>
+</body>
+</pef>

--- a/test/org/daisy/dotify/engine/impl/resource-files/marker-ref-page-content-input.obfl
+++ b/test/org/daisy/dotify/engine/impl/resource-files/marker-ref-page-content-input.obfl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<obfl version="2011-1" xml:lang="en" xmlns="http://www.daisy.org/ns/2011/obfl">
+	<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+		<dc:title>Marker reference page-content search test</dc:title>
+		<dc:description>Tests marker references within a page.</dc:description>
+	</meta>
+	<layout-master name="main" page-width="20" page-height="6" inner-margin="0" outer-margin="0" row-spacing="1" duplex="true">
+		<default-template>
+			<header>
+				<field>
+					<marker-reference marker="pagenum" direction="forward" scope="page-content"/>
+				</field>
+				<field>
+					<marker-reference marker="pagenum" direction="backward" scope="page-content"/>
+				</field>
+			</header>
+			<footer/>
+		</default-template>
+	</layout-master>
+	<sequence master="main" initial-page-number="1">
+		<block><marker class="pagenum" value="1"/><marker class="pagenum" value="2"/></block>
+		<block>⠤⠤<marker class="pagenum" value="3"/>⠤⠤<marker class="pagenum" value="4"/></block>
+	</sequence>
+</obfl>

--- a/test/org/daisy/dotify/engine/impl/resource-files/marker-ref-spread-content-expected.pef
+++ b/test/org/daisy/dotify/engine/impl/resource-files/marker-ref-spread-content-expected.pef
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pef version="2008-1" xmlns="http://www.daisy.org/ns/2008/pef">
+<head>
+<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:format>application/x-pef+xml</dc:format>
+<dc:identifier>identifier?</dc:identifier>
+<dc:date>2015-10-21</dc:date>
+<dc:title>Marker reference search test</dc:title>
+<dc:description>Tests marker references within a page.</dc:description>
+</meta>
+</head>
+<body>
+<volume cols="20" rows="6" rowgap="0" duplex="true">
+<section>
+<page>
+<row>⠼⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠉</row>
+<row>⠤⠤⠤⠤</row>
+</page>
+<page>
+<row>⠼⠑⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠊</row>
+<row>⠤⠤⠤⠤</row>
+</page>
+<page>
+<row>⠼⠑⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠊</row>
+<row>⠤⠤⠤⠤</row>
+</page>
+<page>
+<row>⠼⠁⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠃</row>
+<row>⠤⠤⠤⠤</row>
+</page>
+</section>
+</volume>
+</body>
+</pef>

--- a/test/org/daisy/dotify/engine/impl/resource-files/marker-ref-spread-content-input.obfl
+++ b/test/org/daisy/dotify/engine/impl/resource-files/marker-ref-spread-content-input.obfl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<obfl version="2011-1" xml:lang="en" xmlns="http://www.daisy.org/ns/2011/obfl">
+	<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+		<dc:title>Marker reference spread-content search test</dc:title>
+		<dc:description>Tests marker references within a spread. Note that fields are different on left/right hand sides
+		due to the fact that the scope does not effect the starting point of the search. The starting point is always the
+		current page.</dc:description>
+	</meta>
+	<layout-master name="main" page-width="20" page-height="6" inner-margin="0" outer-margin="0" row-spacing="1" duplex="true">
+		<template use-when="(= (% $page 2) 0)">
+			<header>
+				<field>
+					<marker-reference marker="pagenum" direction="forward" scope="spread-content"/>
+				</field>
+				<field>
+					<marker-reference marker="pagenum" direction="backward" scope="spread-content" start-offset="1"/>
+				</field>
+			</header>
+			<footer/>
+		</template>
+		<default-template>
+			<header>
+				<field>
+					<marker-reference marker="pagenum" direction="forward" scope="spread-content" start-offset="-1"/>
+				</field>
+				<field>
+					<marker-reference marker="pagenum" direction="backward" scope="spread-content"/>
+				</field>
+			</header>
+			<footer/>
+		</default-template>
+	</layout-master>
+	<sequence master="main" initial-page-number="1">
+		<block break-before="page">
+			<block><marker class="pagenum" value="1"/></block>
+			⠤⠤<marker class="pagenum" value="2"/>⠤⠤<marker class="pagenum" value="3"/></block>
+		<block break-before="page">
+			<block><marker class="pagenum" value="4"/></block>
+			⠤⠤<marker class="pagenum" value="5"/>⠤⠤<marker class="pagenum" value="6"/></block>
+		<block break-before="page">
+			<block><marker class="pagenum" value="7"/></block>
+			⠤⠤<marker class="pagenum" value="8"/>⠤⠤<marker class="pagenum" value="9"/></block>
+		<block break-before="page">
+			<block><marker class="pagenum" value="10"/></block>
+			⠤⠤<marker class="pagenum" value="11"/>⠤⠤<marker class="pagenum" value="12"/></block>
+	</sequence>
+</obfl>


### PR DESCRIPTION
See issues https://github.com/brailleapps/dotify/issues/144 and https://github.com/brailleapps/dotify/issues/150

Depends on https://github.com/brailleapps/dotify.api/pull/10