### PR TITLE
Remove "no block allowed within block with underline properties" restriction

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/FormatterCoreImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/FormatterCoreImpl.java
@@ -101,9 +101,6 @@ class FormatterCoreImpl extends Stack<Block> implements FormatterCore, BlockGrou
 		rightMargin.push(new MarginComponent(rb, p.getMargin().getRightSpacing(), p.getPadding().getRightSpacing()));
 		if (propsContext.size()>0) {
 			addToBlockIndent(propsContext.peek().getBlockProperties().getBlockIndent());
-			if (propsContext.peek().getBlockProperties().getUnderlineStyle()!=null) {
-				throw new UnsupportedOperationException("No block allowed within a block with underline properties.");
-			}
 		}
 
 		RowDataProperties.Builder rdp = new RowDataProperties.Builder().
@@ -243,9 +240,10 @@ class FormatterCoreImpl extends Stack<Block> implements FormatterCore, BlockGrou
 						blockIndentParent(blockIndentParent.peek()).
 						leftMargin((Margin)leftMargin.clone()). //.stackMarginComp(formatterContext, false, false)
 						//leftMarginParent((Margin)leftMargin.clone()). //.stackMarginComp(formatterContext, true, false)
-						rightMargin((Margin)rightMargin.clone())//. //.stackMarginComp(formatterContext, false, true)
+						rightMargin((Margin)rightMargin.clone()). //.stackMarginComp(formatterContext, false, true)
 						//rightMarginParent((Margin)rightMargin.clone())
-						; //.stackMarginComp(formatterContext, true, true)
+						//.stackMarginComp(formatterContext, true, true)
+						underlineStyle(p.getUnderlineStyle());
 			Block c = newBlock(null, rdp.build());
 			c.setKeepType(keep);
 			c.setKeepWithNext(next);

--- a/test/org/daisy/dotify/engine/impl/TakenFromDP2Test.java
+++ b/test/org/daisy/dotify/engine/impl/TakenFromDP2Test.java
@@ -341,7 +341,7 @@ public class TakenFromDP2Test extends AbstractFormatterEngineTest {
 		testPEF("resource-files/dp2/block-underline-styles-input.obfl",
 		        "resource-files/dp2/block-underline-styles-expected.pef", false);
 	}
-	@Test(expected=UnsupportedOperationException.class)
+	@Ignore // undefined behavior
 	public void testBlockUnderlineWithChildBlock() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/dp2/block-underline-with-child-block-input.obfl",
 		        "resource-files/dp2/block-underline-with-child-block-expected.pef", false);

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/block-underline-with-child-block-expected.pef
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/block-underline-with-child-block-expected.pef
@@ -3,7 +3,7 @@
    <head>
       <meta>
          <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">block-underline-with-child-block</dc:title>
-         <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests underlining of a block with a child block. Currently causes an error because the behavior is undefined.</dc:description>
+         <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests underlining of a block with a child block.</dc:description>
          <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
       </meta>
    </head>

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/block-underline-with-child-block-input.obfl
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/block-underline-with-child-block-input.obfl
@@ -2,7 +2,7 @@
 <obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="und" hyphenate="false">
    <meta>
       <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">block-underline-with-child-block</dc:title>
-      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests underlining of a block with a child block. Currently causes an error because the behavior is undefined.</dc:description>
+      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests underlining of a block with a child block.</dc:description>
    </meta>
    <layout-master name="main" duplex="false" page-width="15" page-height="15">
       <default-template>


### PR DESCRIPTION
According to OBFL the behavior is unspecified, but it is OK to allow
it. If a block with underline properties contains an empty block with
text following but not preceding, or preceding but not following, the
behavior is as if the empty block was not present.