### PR TITLE
Fix issue #15 again and add a regression test

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -17,6 +17,7 @@ import org.daisy.dotify.common.split.SplitPointHandler;
 import org.daisy.dotify.common.split.SplitPointSpecification;
 import org.daisy.dotify.common.split.StandardSplitOption;
 import org.daisy.dotify.common.split.Supplements;
+import org.daisy.dotify.formatter.impl.common.FormatterCoreContext;
 import org.daisy.dotify.formatter.impl.core.Block;
 import org.daisy.dotify.formatter.impl.core.BlockContext;
 import org.daisy.dotify.formatter.impl.core.ContentCollectionImpl;
@@ -26,7 +27,6 @@ import org.daisy.dotify.formatter.impl.core.PaginatorException;
 import org.daisy.dotify.formatter.impl.row.AbstractBlockContentManager;
 import org.daisy.dotify.formatter.impl.row.MarginProperties;
 import org.daisy.dotify.formatter.impl.row.RowImpl;
-import org.daisy.dotify.formatter.impl.search.CrossReferenceHandler;
 import org.daisy.dotify.formatter.impl.search.DefaultContext;
 import org.daisy.dotify.formatter.impl.search.DocumentSpace;
 import org.daisy.dotify.formatter.impl.search.PageDetails;
@@ -261,17 +261,16 @@ public class PageSequenceBuilder2 {
 					// clone the row as not to append the margins twice
 					RowImpl.Builder b = new RowImpl.Builder(r);
 					if (r.shouldAdjustForMargin()) {
-						MarkerRef rf = r::hasMarkerWithName;
-						MarginProperties margin = r.getLeftMargin();
-						for (MarginRegion mr : p.getPageTemplate().getLeftMarginRegion()) {
-							margin = getMarginRegionValue(mr, rf, false).append(margin);
-						}
-						b.leftMargin(margin);
-						margin = r.getRightMargin();
-						for (MarginRegion mr : p.getPageTemplate().getRightMarginRegion()) {
-							margin = margin.append(getMarginRegionValue(mr, rf, true));
-						}
-						b.rightMargin(margin);
+						b.leftMargin(
+							p.getPageTemplate().getLeftMarginRegion()
+								.stream()
+								.map(mr->getMarginRegionValue(context, mr, r::hasMarkerWithName, false))
+								.reduce(r.getLeftMargin(), (mr, mf) -> mr.append(mf)));
+						b.rightMargin(
+							p.getPageTemplate().getRightMarginRegion()
+								.stream()
+								.map(mr -> getMarginRegionValue(context, mr, r::hasMarkerWithName, true))
+								.reduce(r.getRightMargin(), (mr, mf) -> mr.append(mf)));						
 					}
 					if (i == 0 && j == 0) {
 						// this is the last row; set row spacing to 1 because this is how sph treated it
@@ -306,7 +305,7 @@ public class PageSequenceBuilder2 {
 		boolean hasMarkerWithName(String name);
 	}
 	
-	private MarginProperties getMarginRegionValue(MarginRegion mr, MarkerRef r, boolean rightSide) throws PaginatorException {
+	private static MarginProperties getMarginRegionValue(FormatterCoreContext context, MarginRegion mr, MarkerRef r, boolean rightSide) throws PaginatorException {
 		String ret = "";
 		int w = mr.getWidth();
 		if (mr instanceof MarkerIndicatorRegion) {
@@ -338,7 +337,7 @@ public class PageSequenceBuilder2 {
 		}
 	}
 	
-	private String firstMarkerForRow(MarkerRef r, MarkerIndicatorRegion mrr) {
+	private static String firstMarkerForRow(MarkerRef r, MarkerIndicatorRegion mrr) {
 		return mrr.getIndicators().stream()
 				.filter(mi -> r.hasMarkerWithName(mi.getName()))
 				.map(mi -> mi.getIndicator())

--- a/src/org/daisy/dotify/formatter/impl/row/BlockContentManager.java
+++ b/src/org/daisy/dotify/formatter/impl/row/BlockContentManager.java
@@ -5,6 +5,7 @@ import static java.lang.Math.min;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.regex.Pattern;
 
 import org.daisy.dotify.api.formatter.Context;
@@ -139,8 +140,20 @@ public class BlockContentManager extends AbstractBlockContentManager {
 				return false;
 			}
 			Segment s = segments.get(segmentIndex);
-			if (testOnly && s.getSegmentType()!=SegmentType.Marker && s.getSegmentType()!=SegmentType.Anchor) {
-				return true;
+			if (testOnly) {
+				switch (s.getSegmentType()) {
+				case Marker:
+				case Anchor:
+					break;
+				case Evaluate:
+					if (!((Evaluate)s).getExpression().render(context).isEmpty()) {
+						return true;
+					} else {
+						break;
+					}
+				default:
+					return true;
+				}
 			}
 			layoutSegment(s);
 			segmentIndex++;
@@ -364,9 +377,13 @@ public class BlockContentManager extends AbstractBlockContentManager {
     @Override
     public RowImpl getNext() {
     	ensureBuffer(rowIndex+1);
-        RowImpl ret = rows.get(rowIndex);
-        rowIndex++;
-        return ret;
+        try {
+            RowImpl ret = rows.get(rowIndex);
+            rowIndex++;
+            return ret;
+        } catch (IndexOutOfBoundsException e) {
+            throw new NoSuchElementException();
+        }
     }
 
 	private void layout(String c, String locale, String mode) {

--- a/src/org/daisy/dotify/formatter/impl/row/MarginProperties.java
+++ b/src/org/daisy/dotify/formatter/impl/row/MarginProperties.java
@@ -19,7 +19,8 @@ public final class MarginProperties {
 	}
 	
 	/**
-	 * Creates a new margin with the supplied margin appended. 
+	 * Creates a new margin with the supplied margin appended.
+	 * This operation is associative.
 	 * @param mp the margin to append
 	 * @return the new margin
 	 */

--- a/test/org/daisy/dotify/engine/impl/resource-files/dp2/collapsing-margins-empty-block-input.obfl
+++ b/test/org/daisy/dotify/engine/impl/resource-files/dp2/collapsing-margins-empty-block-input.obfl
@@ -13,6 +13,7 @@
    <sequence master="a">
       <block margin-bottom="1">⠿ </block>
       <block margin-bottom="1"/>
+	  <block margin-bottom="1"><evaluate expression="&#34;&#34;"/></block>
       <block margin-top="1">⠿ </block>
    </sequence>
 </obfl>

--- a/test/org/daisy/dotify/formatter/impl/row/MarginPropertiesTest.java
+++ b/test/org/daisy/dotify/formatter/impl/row/MarginPropertiesTest.java
@@ -1,0 +1,20 @@
+package org.daisy.dotify.formatter.impl.row;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MarginPropertiesTest {
+
+	@Test
+	public void testAssociative() {
+		// (a op b) op c == a op (b op c)
+		MarginProperties a = new MarginProperties(" a", false);
+		MarginProperties b = new MarginProperties(" ", true);
+		MarginProperties c = new MarginProperties("c ", false);
+		MarginProperties abc = new MarginProperties(" a c ", false);
+		assertEquals(abc, a.append(b).append(c));
+		assertEquals(abc, a.append(b.append(c)));
+	}
+}
+


### PR DESCRIPTION
BlockContentManager.hasNext() should return false if the block only contains an expression which is empty when evaluated.

See issue https://github.com/brailleapps/dotify.formatter.impl/pull/15 and commit 7d5b513.