### PR TITLE
Support keeping segments together

### DIFF
--- a/integrationtest/org/daisy/dotify/formatter/test/LeaderTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/LeaderTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.daisy.dotify.api.engine.LayoutEngineException;
 import org.daisy.dotify.api.writer.PagedMediaWriterConfigurationException;
+import org.junit.Ignore;
 import org.junit.Test;
 @SuppressWarnings("javadoc")
 public class LeaderTest extends AbstractFormatterEngineTest {
@@ -14,8 +15,13 @@ public class LeaderTest extends AbstractFormatterEngineTest {
 	}
 	
 	@Test
-	public void testLeaderSimpleRight() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
+	public void testLeaderSimpleRight_01() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/leader-right-simple-input.obfl", "resource-files/leader-right-simple-expected.pef", false);
+	}
+	
+	@Test @Ignore("Demonstrates an issue with leaders")
+	public void testLeaderSimpleRight_02() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
+		testPEF("resource-files/leader-right-simple2-input.obfl", "resource-files/leader-right-simple2-expected.pef", false);
 	}
 	
 	@Test

--- a/integrationtest/org/daisy/dotify/formatter/test/LeaderTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/LeaderTest.java
@@ -19,7 +19,7 @@ public class LeaderTest extends AbstractFormatterEngineTest {
 		testPEF("resource-files/leader-right-simple-input.obfl", "resource-files/leader-right-simple-expected.pef", false);
 	}
 	
-	@Test @Ignore("Demonstrates an issue with leaders")
+	@Test
 	public void testLeaderSimpleRight_02() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/leader-right-simple2-input.obfl", "resource-files/leader-right-simple2-expected.pef", false);
 	}

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/leader-right-simple2-expected.pef
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/leader-right-simple2-expected.pef
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pef version="2008-1" xmlns="http://www.daisy.org/ns/2008/pef">
+<head>
+<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+<dc:format>application/x-pef+xml</dc:format>
+<dc:identifier>identifier?</dc:identifier>
+</meta>
+</head>
+<body>
+<volume cols="10" rows="6" rowgap="0" duplex="false">
+<section>
+<page>
+<row>⠤</row>
+<row>⠿⠿⠿⠿⠀⠿⠿⠿⠿</row>
+<row>⠿⠿⠿⠿⠄⠄⠄⠄⠼⠁</row>
+</page>
+</section>
+</volume>
+</body>
+</pef>

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/leader-right-simple2-input.obfl
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/leader-right-simple2-input.obfl
@@ -1,0 +1,16 @@
+<obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="en">
+	<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+		<dc:title>Simple leader test 2</dc:title>
+		<dc:description>Tests a single right aligned leader with a only one item after</dc:description>
+	</meta>
+	<layout-master name="a" duplex="false" page-width="10" page-height="6">
+		<default-template>
+			<header/>
+			<footer/>
+		</default-template>
+	</layout-master>
+	<sequence master="a">
+		<block id="chapter_1">⠤</block>
+		<block>⠿⠿⠿⠿ ⠿⠿⠿⠿ ⠿⠿⠿⠿<leader position="100%" align="right" pattern="."/><page-number ref-id="chapter_1" number-format="default"/></block>
+	</sequence>
+</obfl>

--- a/src/org/daisy/dotify/formatter/impl/row/AggregatedBrailleTranslatorResult.java
+++ b/src/org/daisy/dotify/formatter/impl/row/AggregatedBrailleTranslatorResult.java
@@ -3,6 +3,7 @@ package org.daisy.dotify.formatter.impl.row;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.daisy.dotify.api.formatter.Marker;
@@ -18,6 +19,9 @@ import org.daisy.dotify.formatter.impl.segment.MarkerSegment;
  * @author Joel Håkansson
  */
 class AggregatedBrailleTranslatorResult implements BrailleTranslatorResult {
+	
+	private static final Pattern trailingWsBraillePattern = Pattern.compile("[\\s\u2800]+\\z");
+	
 	private final List<Object> results;
 	private int currentIndex;
 	private List<Marker> pendingMarkers;
@@ -69,6 +73,10 @@ class AggregatedBrailleTranslatorResult implements BrailleTranslatorResult {
 			results.add(bts);
 		}
 		
+		boolean isEmpty() {
+			return results.isEmpty();
+		}
+		
 		/**
 		 * Builds an aggregated braille translator result based on the
 		 * state of this builder.
@@ -112,7 +120,11 @@ class AggregatedBrailleTranslatorResult implements BrailleTranslatorResult {
 		String row = "";
 		BrailleTranslatorResult current = computeNext();
 		while (limit > row.length()) {
-			row += current.nextTranslatedRow(limit - row.length(), force);
+			row += current.nextTranslatedRow(limit - row.length(), force && row.isEmpty());
+			if (current.hasNext()) {
+				row = trailingWsBraillePattern.matcher(row).replaceAll("");
+				break;
+			}
 			current = computeNext();
 			if (current == null) {
 				break;

--- a/src/org/daisy/dotify/formatter/impl/row/CurrentResultImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/row/CurrentResultImpl.java
@@ -137,9 +137,6 @@ class CurrentResultImpl implements CurrentResult {
 				// always discard leader
 				spi.getLeaderManager().removeLeader();
 			}
-		} else {
-			// there may have been a null leader
-			spi.getLeaderManager().removeLeader();
 		}
 		breakNextRow(m1, spi.getCurrentRow(), btr, tabSpace, lineProps.suppressHyphenation());
 		return Optional.ofNullable(ret);

--- a/src/org/daisy/dotify/formatter/impl/row/CurrentResultImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/row/CurrentResultImpl.java
@@ -137,6 +137,9 @@ class CurrentResultImpl implements CurrentResult {
 				// always discard leader
 				spi.getLeaderManager().removeLeader();
 			}
+		} else {
+			// there may have been a null leader
+			spi.getLeaderManager().removeLeader();
 		}
 		breakNextRow(m1, spi.getCurrentRow(), btr, tabSpace, lineProps.suppressHyphenation());
 		return Optional.ofNullable(ret);
@@ -146,7 +149,9 @@ class CurrentResultImpl implements CurrentResult {
 		int contentLen = StringTools.length(tabSpace) + StringTools.length(row.getText());
 		boolean force = contentLen == 0;
 		//don't know if soft hyphens need to be replaced, but we'll keep it for now
-		String next = softHyphenPattern.matcher(btr.nextTranslatedRow(m1.getMaxLength(row) - contentLen, force, wholeWordsOnly)).replaceAll("");
+		String next = !btr.hasNext()
+			? ""
+			: softHyphenPattern.matcher(btr.nextTranslatedRow(m1.getMaxLength(row) - contentLen, force, wholeWordsOnly)).replaceAll("");
 		if ("".equals(next) && "".equals(tabSpace)) {
 			row.text(m1.getPreContent() + trailingWsBraillePattern.matcher(row.getText()).replaceAll(""));
 		} else {

--- a/src/org/daisy/dotify/formatter/impl/row/LeaderManager.java
+++ b/src/org/daisy/dotify/formatter/impl/row/LeaderManager.java
@@ -4,7 +4,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.Optional;
 
 import org.daisy.dotify.api.formatter.Leader;
 import org.daisy.dotify.api.translator.BrailleTranslator;
@@ -14,7 +13,7 @@ import org.daisy.dotify.common.text.StringTools;
 
 class LeaderManager {
 	private static final Logger logger = Logger.getLogger(LeaderManager.class.getCanonicalName());
-	private Deque<Optional<Leader>> leaders;
+	private Deque<Leader> leaders;
 
 	LeaderManager() {
 		this.leaders = new ArrayDeque<>();
@@ -25,11 +24,11 @@ class LeaderManager {
 	}
 
 	void addLeader(Leader leader) {
-		this.leaders.addLast(Optional.ofNullable(leader));
+		this.leaders.addLast(leader);
 	}
 
 	boolean hasLeader() {
-		return !leaders.isEmpty() && leaders.getFirst().isPresent();
+		return !leaders.isEmpty();
 	}
 
 	void removeLeader() {
@@ -41,7 +40,7 @@ class LeaderManager {
 	}
 	
 	Leader getCurrentLeader() {
-		return leaders.getFirst().get();
+		return leaders.getFirst();
 	}
 
 	int getLeaderPosition(int width) {

--- a/src/org/daisy/dotify/formatter/impl/row/LeaderManager.java
+++ b/src/org/daisy/dotify/formatter/impl/row/LeaderManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Optional;
 
 import org.daisy.dotify.api.formatter.Leader;
 import org.daisy.dotify.api.translator.BrailleTranslator;
@@ -13,7 +14,7 @@ import org.daisy.dotify.common.text.StringTools;
 
 class LeaderManager {
 	private static final Logger logger = Logger.getLogger(LeaderManager.class.getCanonicalName());
-	private Deque<Leader> leaders;
+	private Deque<Optional<Leader>> leaders;
 
 	LeaderManager() {
 		this.leaders = new ArrayDeque<>();
@@ -24,11 +25,11 @@ class LeaderManager {
 	}
 
 	void addLeader(Leader leader) {
-		this.leaders.addLast(leader);
+		this.leaders.addLast(Optional.ofNullable(leader));
 	}
 
 	boolean hasLeader() {
-		return !leaders.isEmpty();
+		return !leaders.isEmpty() && leaders.getFirst().isPresent();
 	}
 
 	void removeLeader() {
@@ -40,7 +41,7 @@ class LeaderManager {
 	}
 	
 	Leader getCurrentLeader() {
-		return leaders.getFirst();
+		return leaders.getFirst().get();
 	}
 
 	int getLeaderPosition(int width) {

--- a/src/org/daisy/dotify/formatter/impl/row/SegmentProcessor.java
+++ b/src/org/daisy/dotify/formatter/impl/row/SegmentProcessor.java
@@ -39,6 +39,7 @@ class SegmentProcessor implements SegmentProcessing {
 	private AggregatedBrailleTranslatorResult.Builder pending;
 	private String currentLeaderMode;
 	private final LeaderManager leaderManager;
+	private LeaderSegment nextLeader = null;
 	private ListItem item;
 	private int forceCount;
 	private int minLeft;
@@ -164,6 +165,10 @@ class SegmentProcessor implements SegmentProcessing {
 	}
 
 	void prepareNext() {
+		if (nextLeader != null) {
+			leaderManager.addLeader(nextLeader);
+			nextLeader = null;
+		}
 		if (!hasMoreData()) {
 			throw new IllegalStateException();
 		}
@@ -295,7 +300,7 @@ class SegmentProcessor implements SegmentProcessing {
 		try {
 			return layoutPending();
 		} finally {
-			leaderManager.addLeader(ls);
+			nextLeader = ls;
 		}
 	}
 
@@ -406,8 +411,6 @@ class SegmentProcessor implements SegmentProcessing {
 				mode = currentLeaderMode;
 				pending = null;
 			}
-			if (!leaderManager.hasLeader())
-				leaderManager.addLeader(null);
 			CurrentResult cr = new CurrentResultImpl(spc, btr, mode);
 			return Optional.of(cr);
 		}


### PR DESCRIPTION
This solve the problem I described in https://github.com/brailleapps/dotify.api/issues/13 without changing the BrailleTranslator contract. The problem is that currently it may happen that a line is broken exactly in between two segments while it isn't always allowed.

Depends on https://github.com/brailleapps/dotify.formatter.impl/pull/44.