### PR TITLE
Allow right aligned leaders to extend into the box' margin

### DIFF
--- a/integrationtest/org/daisy/dotify/formatter/test/LeaderTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/LeaderTest.java
@@ -22,5 +22,9 @@ public class LeaderTest extends AbstractFormatterEngineTest {
 	public void testLeaderMultipleRight() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/leader-right-multiple-input.obfl", "resource-files/leader-right-multiple-expected.pef", false);
 	}
-
+	
+	@Test
+	public void testLeaderExtendsRight() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
+		testPEF("resource-files/leader-right-extends-input.obfl", "resource-files/leader-right-extends-expected.pef", false);
+	}
 }

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/leader-right-extends-expected.pef
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/leader-right-extends-expected.pef
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pef version="2008-1" xmlns="http://www.daisy.org/ns/2008/pef">
+	<head>
+		<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+			<dc:format>application/x-pef+xml</dc:format>
+			<dc:identifier>identifier?</dc:identifier>
+			<dc:date>2018-04-27</dc:date>
+		</meta>
+	</head>
+	<body>
+		<volume cols="20" rows="10" rowgap="0" duplex="false">
+			<section>
+				<page>
+					<row>⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿</row>
+					<row>⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿⠿</row>
+					<row>⠿⠿⠿⠀⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠤⠀⠿⠿</row>
+				</page>
+			</section>
+		</volume>
+	</body>
+</pef>

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/leader-right-extends-input.obfl
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/leader-right-extends-input.obfl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="und" hyphenate="false">
+   <meta>
+      <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Extending leader</dc:title>
+      <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">Tests a leader that extends into the box' margin.</dc:description>
+   </meta>
+   <layout-master name="a" duplex="false" page-width="20" page-height="10">
+      <default-template>
+         <header/>
+         <footer/>
+      </default-template>
+   </layout-master>
+   <sequence master="a">
+      <block margin-right="4">⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿​⠿
+      <leader pattern="⠤" position="125%" align="right"/> ⠿⠿</block>
+   </sequence>
+</obfl>


### PR DESCRIPTION
I have done this change to implement a requirement that both SBS and NLB had:

- https://github.com/sbsdev/pipeline-mod-sbs/issues/51
- https://github.com/nlbdev/pipeline/issues/169

See also the related braille-css issue: https://github.com/braillespecs/braille-css/issues/21#issuecomment-385033731