### PR TITLE
Various changes related to empty blocks and page breaks

### DIFF
--- a/integrationtest/org/daisy/dotify/formatter/test/MarginTest.java
+++ b/integrationtest/org/daisy/dotify/formatter/test/MarginTest.java
@@ -32,4 +32,9 @@ public class MarginTest extends AbstractFormatterEngineTest {
 	public void testUnevenMargin_01() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
 		testPEF("resource-files/margin/margin-uneven-input.obfl", "resource-files/margin/margin-uneven-expected.pef", false);
 	}
+	
+	@Test
+	public void testCollapsingMargin_05() throws LayoutEngineException, IOException, PagedMediaWriterConfigurationException {
+		testPEF("resource-files/margin/margin3-input.obfl", "resource-files/margin/margin3-expected.pef", false);
+	}
 }

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/margin/margin3-expected.pef
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/margin/margin3-expected.pef
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pef version="2008-1" xmlns="http://www.daisy.org/ns/2008/pef">
+<head>
+<meta xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:generator="http://daisymfc.svn.sourceforge.net/viewvc/daisymfc/trunk/dmfc/transformers/org_pef_dtbook2pef/">
+<dc:format>application/x-pef+xml</dc:format>
+<dc:identifier>identifier?</dc:identifier>
+<dc:date>2019-04-02</dc:date>
+</meta>
+</head>
+<body>
+<volume cols="14" rows="6" rowgap="0" duplex="false">
+<section>
+<page>
+<row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+<row>⠤⠤</row>
+</page>
+</section>
+<section>
+<page>
+<row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+<row>⠤⠤</row>
+</page>
+</section>
+<section>
+<page>
+<row>⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿</row>
+<row>⠤⠤</row>
+</page>
+</section>
+<section>
+<page>
+<row>⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿</row>
+<row>⠤⠤</row>
+</page>
+</section>
+<section>
+<page>
+<row>⠿⠀⠀⠀⠀⠿⠿⠀⠀⠀⠀⠿⠿⠿</row>
+<row>⠤⠤</row>
+<row/>
+<row>⠤⠤</row>
+<row>⠤⠤</row>
+</page>
+</section>
+</volume>
+</body>
+</pef>

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/margin/margin3-input.obfl
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/margin/margin3-input.obfl
@@ -1,0 +1,62 @@
+<obfl xmlns="http://www.daisy.org/ns/2011/obfl" version="2011-1" xml:lang="en">
+	<meta xmlns:dc="http://purl.org/dc/elements/1.1/">
+		<dc:title>Collapsing margins test</dc:title>
+		<dc:description>Tests that empty blocks collapse properly.</dc:description>
+	</meta>
+	<layout-master name="body" page-width="14" page-height="6" duplex="false">
+		<default-template>
+			<header>
+				<field>
+					<marker-reference marker="foo" direction="forward" scope="page"/>
+				</field>
+				<field>
+					<marker-reference marker="foo" direction="forward" scope="page-content"/>
+				</field>
+				<field>
+					<marker-reference marker="foo" direction="backward" scope="page"/>
+				</field>
+			</header>
+			<footer/>
+		</default-template>
+	</layout-master>
+	<sequence master="body">
+		<block margin-bottom="1"/>
+		<block/>
+		<block>⠤⠤</block>
+	</sequence>
+	<sequence master="body">
+		<block/>
+		<block margin-bottom="1"/>
+		<block>⠤⠤</block>
+	</sequence>
+	<sequence master="body">
+		<block margin-bottom="1"/>
+		<block>
+			<marker class="foo" value="⠿"/>
+		</block>
+		<block>⠤⠤</block>
+	</sequence>
+	<sequence master="body">
+		<block>
+			<marker class="foo" value="⠿"/>
+		</block>
+		<block margin-bottom="1"/>
+		<block>⠤⠤</block>
+	</sequence>
+	<sequence master="body">
+		<block margin-bottom="1"/>
+		<block>
+			<marker class="foo" value="⠿"/>
+		</block>
+		<block>⠤⠤</block>
+		<block margin-bottom="1"/>
+		<block>
+			<marker class="foo" value="⠿⠿"/>
+		</block>
+		<block>⠤⠤</block>
+		<block>
+			<marker class="foo" value="⠿⠿⠿"/>
+		</block>
+		<block>⠤⠤</block>
+	</sequence>
+</obfl>

--- a/src/org/daisy/dotify/formatter/impl/page/PageImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageImpl.java
@@ -398,4 +398,7 @@ public class PageImpl implements Page {
 		return details;
 	}
 
+	boolean hasRows() {
+		return hasRows;
+	}
 }

--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -365,11 +365,28 @@ public class PageSequenceBuilder2 {
 					return current;
 				} else if (current!=null && dataGroupsIndex<dataGroups.size()) {
 					BreakBefore nextStart = dataGroups.get(dataGroupsIndex).getBreakBefore();
-					if (nextStart!=BreakBefore.AUTO) {
-						if (nextStart == BreakBefore.SHEET && master.duplex() && pageCount%2==1) {
-							nextEmpty = true;
+					switch (nextStart) {
+					case SHEET:
+						if (master.duplex()) {
+							if (pageCount %2 == 1) { // on recto page
+								if (current.hasRows()) {
+									nextEmpty = true;
+									return current;
+								} else {
+									break; // we are already at the beginning of a recto page
+								}
+							} else { // on verso page
+								return current;
+							}
 						}
-						return current;
+					case PAGE:
+						if (current.hasRows()) {
+							return current;
+						} else {
+							break; // we are already at the beginning of a page
+						}
+					case AUTO:
+					default:
 					}
 				}
 			}

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroupDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroupDataSource.java
@@ -212,6 +212,9 @@ class RowGroupDataSource implements SplitPointDataSource<RowGroup, RowGroupDataS
 	private void newRowGroupSequence(BreakBefore breakBefore, VerticalSpacing vs) {
 		// Vertical spacing isn't used at this stage.
 		if (data.getGroup()!=null) {
+			// this means the return values of ScenarioData.hasSequence() and
+			// ScenarioData.hasResult() did not match those of RowGroupDataSource.hasSequence() and
+			// RowGroupDataSource.hasResult() for the same block
 			throw new IllegalStateException();
 		} else {
 			data.setGroup(new ArrayList<>());

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroupProvider.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroupProvider.java
@@ -133,7 +133,7 @@ class RowGroupProvider {
 			//TODO: Does this interfere with collapsing margins?
 			if (shouldAddGroupForEmptyContent()) {
 				RowGroup.Builder rgb = setPropertiesForFirstContentRowGroup(
-					new RowGroup.Builder(master.getRowSpacing(), new ArrayList<RowImpl>()).mergeable(true).lineProperties(lineProps), 
+					new RowGroup.Builder(master.getRowSpacing(), new ArrayList<RowImpl>()).mergeable(true).lineProperties(lineProps).skippable(true),
 					bc.getRefs(),
 					g
 				);

--- a/src/org/daisy/dotify/formatter/impl/page/ScenarioData.java
+++ b/src/org/daisy/dotify/formatter/impl/page/ScenarioData.java
@@ -46,16 +46,12 @@ class ScenarioData {
 		return size;
 	}
 	
-	private boolean isDataEmpty() {
-		return (dataGroups.isEmpty()||dataGroups.peek().getGroup().isEmpty());
-	}
-	
 	private boolean hasSequence() {
 		return !dataGroups.isEmpty();
 	}
 	
 	private boolean hasResult() {
-		return !isDataEmpty();
+		return !dataGroups.isEmpty();
 	}
 	
 	private void newRowGroupSequence(BreakBefore breakBefore, VerticalSpacing vs) {


### PR DESCRIPTION
- Fix `break-before="page"` when already at the beginning of a page. This includes the cases when the page contains one or more empty blocks, but no non-empty blocks.
- Fix a mismatch between the behavior of ScenarioData and RowGroupDataSource that could result in an IllegalStateException, notably when a `break-before="page"` occurs when there are only empty blocks on the current page, some of which have markers.