### PR TITLE
Various changes to <evaluate/>

### DIFF
--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/current-page-input.obfl
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/current-page-input.obfl
@@ -11,17 +11,17 @@
 		</default-template>
 	</layout-master>
 	<sequence master="main" initial-page-number="1">
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
 	</sequence>
 </obfl>

--- a/integrationtest/org/daisy/dotify/formatter/test/resource-files/current-page2-input.obfl
+++ b/integrationtest/org/daisy/dotify/formatter/test/resource-files/current-page2-input.obfl
@@ -11,16 +11,16 @@
 		</default-template>
 	</layout-master>
 	<sequence master="main" initial-page-number="1">
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/><br/><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
-		<block><evaluate expression="(format {0} $page)"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/><br/><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
+		<block><evaluate expression="$page"/></block>
 	</sequence>
 </obfl>

--- a/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
+++ b/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
@@ -239,6 +239,9 @@ public class VolumeProvider {
 			SectionBuilder sb = new SectionBuilder();
 			for (Sheet ps : ret) {
 				for (PageImpl p : ps.getPages()) {
+					for (String id : p.getIdentifiers()) {
+						crh.setVolumeNumber(id, currentVolumeNumber);
+					}
 					if (p.getAnchors().size()>0) {
 						ad.add(new AnchorData(p.getAnchors(), p.getPageNumber()));
 					}

--- a/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
+++ b/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
@@ -126,7 +126,7 @@ public class VolumeProvider {
 		VolumeImpl volume = new VolumeImpl(crh.getOverhead(currentVolumeNumber));
 		ArrayList<AnchorData> ad = new ArrayList<>();
 		volume.setPreVolData(updateVolumeContents(currentVolumeNumber, ad, true));
-		volume.setBody(nextBodyContents(volume.getOverhead().total(), ad));
+		volume.setBody(nextBodyContents(currentVolumeNumber, volume.getOverhead().total(), ad));
 		
 		if (logger.isLoggable(Level.FINE)) {
 			logger.fine("Sheets  in volume " + currentVolumeNumber + ": " + (volume.getVolumeSize()) + 
@@ -148,9 +148,9 @@ public class VolumeProvider {
 	 * @param ad the anchor data
 	 * @return returns the contents of the next volume
 	 */
-	private SectionBuilder nextBodyContents(final int overhead, ArrayList<AnchorData> ad) {
+	private SectionBuilder nextBodyContents(int volumeNumber, final int overhead, ArrayList<AnchorData> ad) {
 		groups.currentGroup().setOverheadCount(groups.currentGroup().getOverheadCount() + overhead);
-		final int splitterMax = splitterLimit.getSplitterLimit(currentVolumeNumber);
+		final int splitterMax = splitterLimit.getSplitterLimit(volumeNumber);
 		final int targetSheetsInVolume = (groups.lastInGroup()?splitterMax:groups.sheetsInCurrentVolume());
 		//Not using lambda for now, because it's noticeably slower.
 		SplitPointCost<Sheet> cost = new SplitPointCost<Sheet>(){
@@ -181,7 +181,7 @@ public class VolumeProvider {
 
 		crh.setReadOnly();
 		SheetDataSource data = groups.currentGroup().getUnits();
-		data.setCurrentVolumeNumber(currentVolumeNumber);
+		data.setCurrentVolumeNumber(volumeNumber);
 		SheetDataSource copySource = new SheetDataSource(data);
 		SplitPointSpecification spec = volSplitter.find(splitterMax-overhead, 
 				copySource, 
@@ -197,14 +197,14 @@ public class VolumeProvider {
 		List<Sheet> contents = sp.getHead();
 		int pageCount = Sheet.countPages(contents);
 		crh.commitPageDetails();
-		crh.setVolumeScope(currentVolumeNumber, pageIndex, pageIndex+pageCount);
+		crh.setVolumeScope(volumeNumber, pageIndex, pageIndex+pageCount);
 
 		pageIndex += pageCount;
 		SectionBuilder sb = new SectionBuilder();
 		for (Sheet sheet : contents) {
 			for (PageImpl p : sheet.getPages()) {
 				for (String id : p.getIdentifiers()) {
-					crh.setVolumeNumber(id, currentVolumeNumber);
+					crh.setVolumeNumber(id, volumeNumber);
 				}
 				if (p.getAnchors().size()>0) {
 					ad.add(new AnchorData(p.getAnchors(), p.getPageNumber()));
@@ -240,7 +240,7 @@ public class VolumeProvider {
 			for (Sheet ps : ret) {
 				for (PageImpl p : ps.getPages()) {
 					for (String id : p.getIdentifiers()) {
-						crh.setVolumeNumber(id, currentVolumeNumber);
+						crh.setVolumeNumber(id, volumeNumber);
 					}
 					if (p.getAnchors().size()>0) {
 						ad.add(new AnchorData(p.getAnchors(), p.getPageNumber()));

--- a/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
+++ b/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
@@ -181,12 +181,13 @@ public class VolumeProvider {
 
 		crh.setReadOnly();
 		SheetDataSource data = groups.currentGroup().getUnits();
+		data.setCurrentVolumeNumber(currentVolumeNumber);
 		SheetDataSource copySource = new SheetDataSource(data);
 		SplitPointSpecification spec = volSplitter.find(splitterMax-overhead, 
 				copySource, 
 				cost, StandardSplitOption.ALLOW_FORCE);
 		crh.setReadWrite();
-		sp = volSplitter.split(spec, groups.currentGroup().getUnits());
+		sp = volSplitter.split(spec, data);
 		/*
 			sp = volSplitter.split(splitterMax-overhead, 
 					groups.currentGroup().getUnits(),

--- a/src/org/daisy/dotify/formatter/impl/obfl/ExpressionImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ExpressionImpl.java
@@ -186,7 +186,6 @@ class ExpressionImpl implements Expression {
 	private Object doEvaluate(String expr) {
 		
 		expr = expr.trim();
-		expr = expr.replaceAll("\\s+", " ");
 		int leftPar = expr.indexOf('(');
 		int rightPar = expr.lastIndexOf(')');
 		if (leftPar==-1 && rightPar==-1) {
@@ -439,6 +438,7 @@ class ExpressionImpl implements Expression {
 			}
 			else if (expr.charAt(i)==' ' && level==0 && !str) {
 				ret.add(expr.substring(ci, i));
+				while (i+1<expr.length() && expr.charAt(i+1)==' ') { i++; }
 				ci=i+1;
 			}
 		}

--- a/src/org/daisy/dotify/formatter/impl/obfl/ExpressionImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ExpressionImpl.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import org.daisy.dotify.api.formatter.NumeralStyle;
 import org.daisy.dotify.api.obfl.Expression;
@@ -102,6 +103,8 @@ class ExpressionImpl implements Expression {
 		globalVars.clear();
 	}
 
+	private static final Pattern IDENT = Pattern.compile("[_a-zA-Z][_a-zA-Z0-9-]*");
+
 	private Object doEval1(String expr) {
 		if (expr.startsWith("\"") && expr.endsWith("\"")) {
 			return expr.substring(1, expr.length()-1);
@@ -109,11 +112,20 @@ class ExpressionImpl implements Expression {
 		if (localVars.containsKey(expr)) {
 			return localVars.get(expr);
 		}
+		if ("true".equals(expr)) {
+			return Boolean.TRUE;
+		}
+		if ("false".equals(expr)) {
+			return Boolean.FALSE;
+		}
+		if (IDENT.matcher(expr).matches()) {
+			return expr;
+		}
 		try {
 			return toNumber(expr);
 		} catch (NumberFormatException e) {
-			return expr;
 		}
+		throw new IllegalArgumentException("Can not evaluate: " + expr);
 	}
 	
 	private Object doEval2(String[] args1) {

--- a/src/org/daisy/dotify/formatter/impl/obfl/ExpressionTools.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ExpressionTools.java
@@ -22,7 +22,7 @@ public class ExpressionTools {
 			return expr;
 		}
 		for (String varName : variables.keySet()) {
-			expr = expr.replaceAll("\\$"+varName+"(?=\\W)", variables.get(varName));
+			expr = expr.replaceAll("\\$"+varName+"($|(?=\\W))", variables.get(varName));
 		}
 		return expr;
 	}
@@ -36,7 +36,7 @@ public class ExpressionTools {
 	public static String resolveVariables(String expr, String ... vars) {
 		for (String var : vars) {
 			String[] v = var.split("=", 2);
-			expr = expr.replaceAll("\\$"+v[0]+"(?=\\W)", v[1]);
+			expr = expr.replaceAll("\\$"+v[0]+"($|(?=\\W))", v[1]);
 		}
 		return expr;
 	}

--- a/src/org/daisy/dotify/formatter/impl/obfl/OBFLExpressionBase.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/OBFLExpressionBase.java
@@ -89,7 +89,12 @@ public abstract class OBFLExpressionBase {
 			variables.put(pageNumberVariable, ""+context.getCurrentPage());
 		}
 		if (volumeNumberVariable!=null) {
-			variables.put(volumeNumberVariable, ""+context.getCurrentVolume());
+			// Passing a default value for the case the current volume is not known. This is the
+			// case during the preparation phase of the VolumeProvider. If we wouldn't pass a value,
+			// the evaluation of an expression with "$volume" would fail. Passing the value "??"
+			// would not work because $volume is expected to be a number, so e.g. arithmetic
+			// operations can be applied to it.
+			variables.put(volumeNumberVariable, context.getCurrentVolume() == null ? "0": (""+context.getCurrentVolume()));
 		}
 		if (volumeCountVariable!=null) {
 			variables.put(volumeCountVariable, ""+context.getVolumeCount());

--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -181,11 +181,6 @@ public class PageSequenceBuilder2 {
 		for (String id : ret.getIdentifiers()) {
 			blockContext.getRefs().setPageNumber(id, ret.getPageNumber());
 		}
-		if (blockContext.getCurrentVolume()!=null) {
-			for (String id : ret.getIdentifiers()) {
-				blockContext.getRefs().setVolumeNumber(id, blockContext.getCurrentVolume());
-			}
-		}
 		toIndex++;
 		return ret;
 	}

--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -44,7 +44,7 @@ public class PageSequenceBuilder2 {
 	private final PageAreaProperties areaProps;
 
 	private final ContentCollectionImpl collection;
-	private final BlockContext blockContext;
+	private BlockContext blockContext;
 	private final CollectionData cd;
 	private final LayoutMaster master;
 	private final List<RowGroupSequence> dataGroups;
@@ -129,6 +129,13 @@ public class PageSequenceBuilder2 {
 		return template==null?null:new PageSequenceBuilder2(template);
 	}
 	
+	public void setCurrentVolumeNumber(int volume) {
+		blockContext = BlockContext.from(blockContext).currentVolume(volume).build();
+		if (data != null) {
+			data.setContext(blockContext);
+		}
+	}
+	
 	/**
 	 * Gets a new PageId representing the next page in this sequence.
 	 * @param offset the offset
@@ -174,7 +181,6 @@ public class PageSequenceBuilder2 {
 		for (String id : ret.getIdentifiers()) {
 			blockContext.getRefs().setPageNumber(id, ret.getPageNumber());
 		}
-		//This is for pre/post volume contents, where the volume number is known
 		if (blockContext.getCurrentVolume()!=null) {
 			for (String id : ret.getIdentifiers()) {
 				blockContext.getRefs().setVolumeNumber(id, blockContext.getCurrentVolume());

--- a/src/org/daisy/dotify/formatter/impl/search/SheetIdentity.java
+++ b/src/org/daisy/dotify/formatter/impl/search/SheetIdentity.java
@@ -8,9 +8,17 @@ public class SheetIdentity {
 
 	public SheetIdentity(Space s, Integer volumeIndex, Integer volumeGroup, int sheetIndex) {
 		this.space = s;
-		if ((space == Space.BODY && (volumeIndex != null || volumeGroup == null))
-		    || (space != Space.BODY && (volumeIndex == null || volumeGroup != null))) {
-			throw new IllegalArgumentException();
+		if (space == Space.BODY) {
+			if (volumeIndex != null) {
+				volumeIndex = null;
+			}
+			if (volumeGroup == null) {
+				throw new IllegalArgumentException();
+			}
+		} else {
+			if (volumeIndex == null || volumeGroup != null) {
+				throw new IllegalArgumentException();
+			}
 		}
 		this.volumeIndex = volumeIndex;
 		this.volumeGroup = volumeGroup;

--- a/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
@@ -38,7 +38,7 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
 	private final PageCounter pageCounter;
 	private final FormatterContext context;
 	//Input data
-	private final DefaultContext rcontext;
+	private DefaultContext rcontext;
 	private final Integer volumeGroup;
 	private final List<BlockSequence> seqsIterator;
 	private final int sheetOffset;
@@ -165,6 +165,13 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
 	@Override
 	public Supplements<Sheet> getSupplements() {
 		return null;
+	}
+	
+	public void setCurrentVolumeNumber(int volume) {
+		rcontext = DefaultContext.from(rcontext).currentVolume(volume).build();
+		if (psb != null) {
+			psb.setCurrentVolumeNumber(volume);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
- Allow evaluation of `$volume` in volume transitions and in normal flow 
- Allow `<evaluate expression="$page"/>`, where you previously had to say `(round $page)` or `(format {0} $page)`
- Be more strict about what is allowed in an expression 
- Don't normalize space in evaluate expressions