### PR TITLE
Why wait with calling setResolver on Evaluate and PageNumberReference?

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/segment/Evaluate.java
+++ b/src/org/daisy/dotify/formatter/impl/segment/Evaluate.java
@@ -1,7 +1,7 @@
 package org.daisy.dotify.formatter.impl.segment;
 
 import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.daisy.dotify.api.formatter.DynamicContent;
 import org.daisy.dotify.api.formatter.TextProperties;
@@ -17,7 +17,7 @@ public class Evaluate implements Segment {
 	private final DynamicContent expression;
 	private final TextProperties props;
 	private final boolean markCapitalLetters;
-	private Supplier<String> v = ()->"";
+	private Function<Evaluate,String> v = (x)->"";
 	private String resolved;
 	
 	/**
@@ -84,13 +84,13 @@ public class Evaluate implements Segment {
 
 	@Override
 	public String peek() {
-		return resolved==null?v.get():resolved;
+		return resolved==null?v.apply(this):resolved;
 	}
 
 	@Override
 	public String resolve() {
 		if (resolved==null) {
-			resolved = v.get();
+			resolved = v.apply(this);
 			if (resolved == null) {
 				resolved = "";
 			}
@@ -98,7 +98,7 @@ public class Evaluate implements Segment {
 		return resolved;
 	}
 
-	public void setResolver(Supplier<String> v) {
+	public void setResolver(Function<Evaluate,String> v) {
 		this.resolved = null;
 		this.v = v;
 	}

--- a/src/org/daisy/dotify/formatter/impl/segment/PageNumberReference.java
+++ b/src/org/daisy/dotify/formatter/impl/segment/PageNumberReference.java
@@ -1,6 +1,6 @@
 package org.daisy.dotify.formatter.impl.segment;
 
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.daisy.dotify.api.formatter.NumeralStyle;
 
@@ -14,7 +14,7 @@ public class PageNumberReference implements Segment {
 	private final String refid;
 	private final NumeralStyle style;
 	private final boolean markCapitalLetters;
-	private Supplier<String> v=()->"";
+	private Function<PageNumberReference,String> v = (x)->"";
 	private String resolved;
 	
 	public PageNumberReference(String refid, NumeralStyle style, boolean markCapitalLetters) {
@@ -90,7 +90,7 @@ public class PageNumberReference implements Segment {
 	@Override
 	public String resolve() {
 		if (resolved==null) {
-			resolved = v.get();
+			resolved = v.apply(this);
 			if (resolved == null) {
 				resolved = "";
 			}
@@ -98,7 +98,7 @@ public class PageNumberReference implements Segment {
 		return resolved;
 	}
 	
-	public void setResolver(Supplier<String> v) {
+	public void setResolver(Function<PageNumberReference,String> v) {
 		this.resolved = null;
 		this.v = v;
 	}


### PR DESCRIPTION
Why wait with calling setResolver on Evaluate and PageNumberReference? This makes it impossible to "peek" a Evaluate or PageNumberReference segment. Instead of calling setResolver when the segments are layed out, I simply call the method when SegmentProcessor is initialized.

I must have done something wrong though because I made a test fail. Do you know what's wrong?

```
org.daisy.dotify.formatter.test.RowByRowTest > testCurrentPage_02 FAILED
    java.lang.AssertionError at RowByRowTest.java:18
```