### PR TITLE
Code documentation in the form of Javadocs and comments

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/FormatterFactoryImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/FormatterFactoryImpl.java
@@ -11,8 +11,11 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
 /**
- * Provides a formatter proxy implementation. This class is intended to be instantiated
- * by the formatter factory, and is not part of the public API.
+ * <p>Provides a {@link FormatterFactory formatter proxy implementation}. This class is intended to
+ * be instantiated by the formatter factory, and is not part of the public API.</p>
+ *
+ * <p>Produces instances of {@link FormatterImpl}.</p>
+ *
  * @author Joel Håkansson
  */
 @Component

--- a/src/org/daisy/dotify/formatter/impl/FormatterImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/FormatterImpl.java
@@ -29,8 +29,16 @@ import org.daisy.dotify.formatter.impl.volume.VolumeTemplate;
 
 
 /**
- * Provides an implementation of the {@link Formatter} API.
- * 
+ * <p>Provides an implementation of the {@link Formatter} API.</p>
+ *
+ * <p>Is used for creating a paged document. Uses {@link
+ * org.daisy.dotify.formatter.impl.VolumeProvider} to produce {@link
+ * org.daisy.dotify.formatter.impl.common.Volume} objects from a list of {@link BlockSequence},
+ * which are provided through {@link #newSequence(SequenceProperties)}, and populated through
+ * methods like {@link BlockSequence#startBlock(BlockProperties)}, {@link
+ * BlockSequence#addChars(CharSequence, TextProperties)}, etc. The resuling paged document is
+ * collected through a {@link org.daisy.dotify.api.writer.PagedMediaWriter}.</p>
+ *
  * @author Joel Håkansson
  */
 class FormatterImpl implements Formatter {

--- a/src/org/daisy/dotify/formatter/impl/FormatterImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/FormatterImpl.java
@@ -55,7 +55,6 @@ class FormatterImpl implements Formatter {
 	 * Creates a new formatter.
 	 * @param translatorFactory a braille translator factory maker service
 	 * @param tbf a text border factory maker service
-	 * @param mpf a marker processor factory maker service
 	 * @param locale a locale
 	 * @param mode a braille mode
 	 */
@@ -67,7 +66,6 @@ class FormatterImpl implements Formatter {
 	 * Creates a new formatter.
 	 * @param translatorFactory a braille translator factory maker service
 	 * @param tbf a text border factory maker service
-	 * @param mpf a marker processor factory maker service
 	 * @param config the configuration
 	 */
 	FormatterImpl(BrailleTranslatorFactoryMakerService translatorFactory, TextBorderFactoryMakerService tbf, FormatterConfiguration config) {

--- a/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
+++ b/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
@@ -82,7 +82,6 @@ public class VolumeProvider {
 	 * @param blocks the block sequences
 	 * @param volumeTemplates volume templates
 	 * @param context the formatter context
-	 * @param crh the cross reference handler
 	 */
 	VolumeProvider(List<BlockSequence> blocks, Stack<VolumeTemplate> volumeTemplates, LazyFormatterContext context) {
 		this.blocks = blocks;

--- a/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
+++ b/src/org/daisy/dotify/formatter/impl/VolumeProvider.java
@@ -234,7 +234,7 @@ public class VolumeProvider {
 					break;
 				}
 			}
-			List<Sheet> ret = prepareToPaginate(ib, c, null).getRemaining();
+			List<Sheet> ret = prepareToPaginatePrePostVolumeContent(ib, c).getRemaining();
 			SectionBuilder sb = new SectionBuilder();
 			for (Sheet ps : ret) {
 				for (PageImpl p : ps.getPages()) {
@@ -250,8 +250,8 @@ public class VolumeProvider {
 		}
 	}
 	
-	private SheetDataSource prepareToPaginate(List<BlockSequence> fs, DefaultContext rcontext, Integer volumeGroup) throws PaginatorException {
-		return prepareToPaginate(new PageCounter(), rcontext, volumeGroup, fs);
+	private SheetDataSource prepareToPaginatePrePostVolumeContent(List<BlockSequence> fs, DefaultContext rcontext) throws PaginatorException {
+		return prepareToPaginate(new PageCounter(), rcontext, null, fs);
 	}
 	
 	private Iterable<SheetDataSource> prepareToPaginateWithVolumeGroups(List<BlockSequence> fs, DefaultContext rcontext) {

--- a/src/org/daisy/dotify/formatter/impl/core/FormatterCoreImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/core/FormatterCoreImpl.java
@@ -47,6 +47,10 @@ import org.daisy.dotify.formatter.impl.segment.NewLineSegment;
 import org.daisy.dotify.formatter.impl.segment.PageNumberReference;
 import org.daisy.dotify.formatter.impl.segment.TextSegment;
 
+/**
+ * <p>Implementation of {@link FormatterCore}. Can contain for example a parsed OBFL
+ * <code>sequence</code>.</p>
+ */
 public class FormatterCoreImpl extends Stack<Block> implements FormatterCore, BlockGroup {
 	/**
 	 * 

--- a/src/org/daisy/dotify/formatter/impl/core/package-info.java
+++ b/src/org/daisy/dotify/formatter/impl/core/package-info.java
@@ -1,5 +1,7 @@
 /**
- * <p>Provides core functionality for the FormatterFactory implementation.</p>
+ * <p>Provides core functionality for the {@link org.daisy.dotify.api.formatter.FormatterFactory}
+ * implementation.</p>
+ *
  * <p><b>IMPORTANT: This package is part of the FormatterFactory implementation 
  * in {@link org.daisy.dotify.formatter.impl}. Classes in this package 
  * should only be used by this implementation.</b></p>

--- a/src/org/daisy/dotify/formatter/impl/engine/LayoutEngineFactoryImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/engine/LayoutEngineFactoryImpl.java
@@ -25,7 +25,10 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
 /**
- * Provides a layout engine factory.
+ * <p>Provides a {@link FormatterEngineFactoryService layout engine factory}.</p>
+ *
+ * <p>Produces instances of {@link LayoutEngineImpl}.</p>
+ *
  * @author Joel Håkansson
  */
 @Component

--- a/src/org/daisy/dotify/formatter/impl/engine/package-info.java
+++ b/src/org/daisy/dotify/formatter/impl/engine/package-info.java
@@ -1,5 +1,9 @@
 /**
- * <p>Provides a {@link org.daisy.dotify.api.engine.FormatterEngineFactoryService} implementation.</p>
+ * <p>Provides an interface for creating a file format defined by a {@link
+ * org.daisy.dotify.api.writer.PagedMediaWriter} from an OBFL.</p>
+ *
+ * <p>Provides a {@link org.daisy.dotify.api.engine.FormatterEngineFactoryService} implementation,
+ * {@link LayoutEngineFactoryImpl}.</p>
  *
  * <p><b>IMPORTANT: This package contains an implementation that should only be 
  * accessed using the Java SPI or OSGi. Additional classes in this package 

--- a/src/org/daisy/dotify/formatter/impl/obfl/BorderBuilder.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/BorderBuilder.java
@@ -8,6 +8,11 @@ import org.daisy.dotify.api.translator.Border.Builder.BuilderView;
 import org.daisy.dotify.api.translator.BorderSpecification.Align;
 import org.daisy.dotify.api.translator.BorderSpecification.Style;
 
+/**
+ * Parses the <a
+ * href="http://braillespecs.github.io/obfl/obfl-specification.html#borders">border-*</a> attributes
+ * and returns a {@link Border} object.
+ */
 class BorderBuilder {
 	
 	private static final String KEY_BORDER = "border";

--- a/src/org/daisy/dotify/formatter/impl/obfl/ObflParserFactoryImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ObflParserFactoryImpl.java
@@ -21,7 +21,10 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 
 /**
- * Provides an expression factory implementation.
+ * <p>Provides an {@link ObflParserFactoryService OBFL parser factory} implementation.</p>
+ *
+ * <p>Produces instances of {@link ObflParserImpl}.</p>
+ *
  * @author Joel Håkansson
  */
 @Component

--- a/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/ObflParserImpl.java
@@ -93,8 +93,10 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 /**
- * Provides a parser for OBFL. The parser accepts OBFL input, either
- * as an InputStream or as an XMLEventReader.
+ * <p>Provides a {@link ObflParser parser for OBFL}.</p>
+ *
+ * <p>The parser accepts OBFL input as an {@link XMLEventReader}. Based on the OBFL it populates the
+ * supplied (empty) {@link Formatter} object.</p>
  *
  * @author Joel Håkansson
  *

--- a/src/org/daisy/dotify/formatter/impl/obfl/package-info.java
+++ b/src/org/daisy/dotify/formatter/impl/obfl/package-info.java
@@ -1,6 +1,11 @@
 /**
- * <p>Provides an {@link org.daisy.dotify.api.obfl.ObflParserFactoryService} implementation and an
- * {@link org.daisy.dotify.api.obfl.ExpressionFactory} implementation.</p>
+ * <p>Provides functionality for creating a {@link org.daisy.dotify.api.formatter.Formatter} from a
+ * OBFL.</p>
+ *
+ * <p>Provides an {@link org.daisy.dotify.api.obfl.ObflParserFactoryService} implementation, {@link
+ * org.daisy.dotify.formatter.impl.obfl.ObflParserFactoryImpl}, and an {@link
+ * org.daisy.dotify.api.obfl.ExpressionFactory} implementation, {@link
+ * org.daisy.dotify.formatter.impl.obfl.ExpressionFactoryImpl}.</p>
  *
  * <p><b>IMPORTANT: This package contains implementations that should only be 
  * accessed using the Java SPI or OSGi. Additional classes in this package 

--- a/src/org/daisy/dotify/formatter/impl/package-info.java
+++ b/src/org/daisy/dotify/formatter/impl/package-info.java
@@ -1,6 +1,8 @@
 /**
  * <p>Provides a {@link org.daisy.dotify.api.formatter.FormatterFactory} implementation.</p>
  *
+ * <p>The main class is {@link org.daisy.dotify.formatter.impl.FormatterFactoryImpl}.</p>
+ *
  * <p><b>IMPORTANT: This package contains an implementation that should only be 
  * accessed using the Java SPI or OSGi. Additional classes in this package 
  * should only be used by the implementation herein.</b>

--- a/src/org/daisy/dotify/formatter/impl/page/BlockSequence.java
+++ b/src/org/daisy/dotify/formatter/impl/page/BlockSequence.java
@@ -11,7 +11,10 @@ import org.daisy.dotify.formatter.impl.core.LayoutMaster;
 
 /**
  * Provides an interface for a sequence of block contents.
- * 
+ *
+ * <p>{@link #selectScenario(LayoutMaster, BlockContext, boolean) selectScenario} is used to access
+ * the blocks, as a list of {@link RowGroupSequence}s (one RowGroupSequence for each block).
+ *
  * @author Joel Håkansson
  */
 public class BlockSequence extends FormatterCoreImpl implements FormatterSequence {

--- a/src/org/daisy/dotify/formatter/impl/page/FieldResolver.java
+++ b/src/org/daisy/dotify/formatter/impl/page/FieldResolver.java
@@ -163,6 +163,12 @@ class FieldResolver {
 		return f.getNumeralStyle().format(pagenum);
 	}
 
+	/**
+	 * @param pagenum the page
+	 * @param rowOffset the row
+	 * @return returns the available width for content on a certain row and page. When there are
+	 *         header or footer fields on the row, the available width is less than the page width.
+	 */
 	public int getWidth(int pagenum, int rowOffset) {
 		while (true) {
 			// Iterates until rowOffset is less than the height of the page.

--- a/src/org/daisy/dotify/formatter/impl/page/PageImpl.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageImpl.java
@@ -29,9 +29,10 @@ import org.daisy.dotify.formatter.impl.search.VolumeKeepPriority;
 
 
 //FIXME: scope spread is currently implemented using document wide scope, i.e. across volume boundaries. This is wrong, but is better than the previous sequence scope.
+
 /**
- * Provides a page object.
- * 
+ * <p>Provides a {@link Page} object.</p>
+ *
  * @author Joel Håkansson
  */
 public class PageImpl implements Page {

--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -38,6 +38,38 @@ import org.daisy.dotify.formatter.impl.search.SequenceId;
 import org.daisy.dotify.formatter.impl.search.TransitionProperties;
 import org.daisy.dotify.formatter.impl.search.VolumeKeepPriority;
 
+/**
+ * <p>Given a {@link BlockSequence}, produces {@link org.daisy.dotify.formatter.impl.common.Page}
+ * objects one by one. The pages are obtained through a {@link #nextPage(int, boolean, Optional,
+ * boolean, boolean) "iterator" interface}.</p>
+ *
+ * <ul>
+ *   <li>Performs page breaking.</li>
+ *   <li>Constructs any "page-area" areas and fills it with collection items that are referenced from anchors on this page.</li>
+ *   <li>Adds any header and footer lines. (This is done in {@link PageImpl}.)</li>
+ *   <li>Adds "<code>margin-region</code>" columns. (This is done in {@link PageImpl}.)</li>
+ *   <li>Adds any "<code>volume-transition</code>" content (<code>sequence-interrupted</code>,
+ *       <code>sequence-resumed</code>, <code>any-interrupted</code> and/or <code>any-resumed</code>).
+ *       <br>
+ *       Note that <code>block-interrupted</code> and <code>block-resumed</code> are currently not implemented.
+ *   </li>
+ * </ul>
+ *
+ * <p>The input is a sequence of blocks, which are first converted to a sequence of {@link
+ * RowGroupSequence}. If a sequence has multiple possible scenarios the best one is selected. Every
+ * <code>RowGroupSequence</code> either starts on a new sheet, a new page, or on a specific position
+ * on the page. A <code>RowGroupSequence</code> that does not fit on the page is broken, using
+ * {@link SplitPointHandler}. The cost function takes into account the gap at the bottom of the
+ * page, whether the {@link RowGroup#isBreakable() isBreakable} and {@link
+ * RowGroup#getAvoidVolumeBreakAfterPriority()} constraints of the last <code>RowGroup</code> are
+ * violated, and whether we're breaking inside a block that can not flow around header/footer fields
+ * while the header/footer does allow it.
+ *
+ * <p>The computed {@link VolumeKeepPriority} of page is the maximum value (lowest priority) of all
+ * {@link RowGroup}s on that page. Discarded {@link RowGroup}s (i.e. collapsed margins) are also
+ * taken into account.</p>
+ */
+
 public class PageSequenceBuilder2 {
 	private final FormatterContext context;
 	private final PageAreaContent staticAreaContent;
@@ -60,14 +92,40 @@ public class PageSequenceBuilder2 {
 	private int dataGroupsIndex;
 	private boolean nextEmpty = false;
 
+	// BlockLineLocation of the last line of the previous page (produced by this PageSequenceBuilder2 or the previous one)
 	private BlockLineLocation cbl;
+	// BlockLineLocation of the last line of the page before the previous page, or null if no page has been produced yet
 	private BlockLineLocation pcbl;
 
 	//From view, temporary
 	private final int fromIndex;
 	private int toIndex;
 
-	public PageSequenceBuilder2(int fromIndex, LayoutMaster master, int pageOffset, BlockSequence seq, FormatterContext context, DefaultContext rcontext, SequenceId seqId, BlockLineLocation blc) {
+	/**
+	 * @param fromIndex "Index" of the first page of this <code>PageSequenceBuilder</code>. The
+	 *     exact value does not matter for <code>PageSequenceBuilder2</code> itself, but {@link
+	 *     org.daisy.dotify.formatter.impl.sheet.SheetDataSource} requires that the values returned
+	 *     by {@link #getGlobalStartIndex()} and {@link #getToIndex()} match the provided value. The
+	 *     value passed by {@link org.daisy.dotify.formatter.impl.sheet.SheetDataSource} is the
+	 *     number of pages that either the whole body, or the pre- or post-content of the current
+	 *     volume, already contains.
+	 * @param master the layout master
+	 * @param pageOffset see the <code>pageNumberOffset</code> parameter in {@link #nextPage(int,
+	 *     boolean, Optional, boolean, boolean) nextPage}.
+	 * @param seq the input block sequence
+	 * @param context ?
+	 * @param rcontext ?
+	 * @param seqId identifier/position of the block sequence
+	 * @param blc The {@link BlockLineLocation} of the last line of the previous PageSequenceBuilder2.
+	 */
+	public PageSequenceBuilder2(int fromIndex,
+	                            LayoutMaster master,
+	                            int pageOffset,
+	                            BlockSequence seq,
+	                            FormatterContext context,
+	                            DefaultContext rcontext,
+	                            SequenceId seqId,
+	                            BlockLineLocation blc) {
 		this.fromIndex = fromIndex;
 		this.toIndex = fromIndex;
 		this.master = master;
@@ -167,7 +225,29 @@ public class PageSequenceBuilder2 {
 		return dataGroupsIndex<dataGroups.size() || (data!=null && !data.isEmpty());
 	}
 	
-	public PageImpl nextPage(int pageNumberOffset, boolean hyphenateLastLine, Optional<TransitionContent> transitionContent, boolean wasSplitInSequence, boolean isFirst) throws PaginatorException, RestartPaginationException // pagination must be restarted in PageStructBuilder.paginateInner
+	/**
+	 * @param pageNumberOffset Page number corresponding to the first page of this
+	 *     <code>PageSequenceBuilder2</code> minus 1, if the page numbering would be continuous
+	 *     between the first and the current page. This does not necessarily match the actual page
+	 *     number of the produced page, because for instance when a volume break happens inside a
+	 *     sequence, there can be a jump in the page numbering.
+	 * @param hyphenateLastLine Whether to allow the last line on the page to end on a hyphenation
+	 *     point (may be the case on the last page of the volume).
+	 * @param transitionContent Content to be inserted at the top (any-resumed and/or
+	 *        sequence-resumed) or at the bottom of the page (any-interrupted and/or
+	 *        sequence-interrupted). any-resumed is only enabled if <code>isFirst</code> is not
+	 *        <code>true</code>, sequence-resumed is only enabled if <code>wasSplitInSequence</code>
+	 *        is <code>true</code>, sequence-interrupted is only enabled if the page is broken
+	 *        within the sequence.
+	 * @param wasSplitInSequence see above
+	 * @param isFirst see above
+	 * @return the next page
+	 */
+	public PageImpl nextPage(int pageNumberOffset,
+	                         boolean hyphenateLastLine,
+	                         Optional<TransitionContent> transitionContent,
+	                         boolean wasSplitInSequence,
+	                         boolean isFirst) throws PaginatorException, RestartPaginationException // pagination must be restarted in PageStructBuilder.paginateInner
 	{
 		PageImpl ret = nextPageInner(pageNumberOffset, hyphenateLastLine, transitionContent, wasSplitInSequence, isFirst);
 		blockContext.getRefs().keepPageDetails(ret.getDetails());
@@ -188,6 +268,10 @@ public class PageSequenceBuilder2 {
 	{
 		PageImpl current = newPage(pageNumberOffset);
 		if (pcbl!=null) {
+			// Store a mapping from the BlockLineLocation of the last line of the page before the
+			// previous page to the BlockLineLocation of the last line of the previous page. This
+			// info is used (in the next iteration) in SheetDataSource to obtain info about the
+			// verso page of a sheet when we are on a recto page of that sheet.
 			blockContext.getRefs().setNextPageDetailsInSequence(pcbl, current.getDetails());
 		}
 		if (nextEmpty) {
@@ -196,16 +280,19 @@ public class PageSequenceBuilder2 {
 		}
 		// The purpose of this is to prevent supplements from combining with header/footer
 		cd.setExtraOverhead(current.getPageTemplate().validateAndAnalyzeHeader() + current.getPageTemplate().validateAndAnalyzeFooter());
+		// while there are more rows in the current block, or there are more blocks...
 		while (dataGroupsIndex<dataGroups.size() || (data!=null && !data.isEmpty())) {
 			if ((data==null || data.isEmpty()) && dataGroupsIndex<dataGroups.size()) {
-				//pick up next group
+				// pick up next block (as RowGroupSequence)
 				RowGroupSequence rgs = dataGroups.get(dataGroupsIndex);
 				//TODO: This assumes that all page templates have margin regions that are of the same width
 				BlockContext bc = BlockContext.from(blockContext)
 						.flowWidth(master.getFlowWidth() - master.getTemplate(current.getPageNumber()).getTotalMarginRegionWidth())
 						.build();
+				// convert to RowGroupDataSource
 				data = new RowGroupDataSource(master, bc, rgs.getBlocks(), rgs.getBreakBefore(), rgs.getVerticalSpacing(), cd);
 				dataGroupsIndex++;
+				// perform vertical positioning by inserting empty rows
 				if (((RowGroupDataSource)data).getVerticalSpacing()!=null) {
 					VerticalSpacing vSpacing = ((RowGroupDataSource)data).getVerticalSpacing();
 					float size = 0;
@@ -225,6 +312,9 @@ public class PageSequenceBuilder2 {
 					.flowWidth(master.getFlowWidth() - master.getTemplate(current.getPageNumber()).getTotalMarginRegionWidth())
 					.build();
 			data.setContext(bc);
+			// This function returns the space that header or footer fields take up in a row at a
+			// certain position on the page. RowGroupDataSource needs this information in order to
+			// know where to break the line.
 			Function<Integer, Integer> reservedWidths = x->{
 				return master.getFlowWidth()-fieldResolver.getWidth(current.getPageNumber(), x);
 			}; 
@@ -242,9 +332,13 @@ public class PageSequenceBuilder2 {
 				data = sl.getTail();
 				// And on copy...
 				copy = SplitPointHandler.skipLeading(copy, index).getTail();
+				// Content of sequence-interrupted or sequence-resumed (which of the two depends on
+				// whether we are at the beginning or the end of the volume)
 				List<RowGroup> seqTransitionText = transitionContent.isPresent()
 						?new RowGroupDataSource(master, bc, transitionContent.get().getInSequence(), BreakBefore.AUTO, null, cd).getRemaining()
 						:Collections.emptyList();
+				// Content of any-interrupted or any-resumed (which of the two depends on whether we
+				// are at the beginning or the end of the volume)
 				List<RowGroup> anyTransitionText; {
 					if (transitionContent.isPresent()
 					    && !(transitionContent.get().getType() == TransitionContent.Type.RESUME && isFirst)) {
@@ -255,6 +349,7 @@ public class PageSequenceBuilder2 {
 					}
 				}
 				float anyHeight = height(anyTransitionText, true);
+				// First find the optimal break point
 				SplitPointSpecification spec;
 				boolean addTransition = true;
 				if (transitionContent.isPresent() && transitionContent.get().getType()==Type.INTERRUPT) {
@@ -280,11 +375,12 @@ public class PageSequenceBuilder2 {
 									:21 // because 11 + 9 = 20
 								)*limit-in;
 					};
-					// Finding from the full height
+					// Find break point with full height available, i.e. without sequence-interrupted subtracted
 					spec = sph.find(current.getFlowHeight() - anyHeight, copy, cost, force?StandardSplitOption.ALLOW_FORCE:null);
 					SplitPoint<RowGroup, RowGroupDataSource> x = sph.split(spec, copy);
-					// If the tail is empty, there's no need for a transition
-					// If there isn't a transition between blocks available, don't insert the text
+					// If the tail is empty, there's no need for a transition.
+					// If there isn't a boundary between blocks available to break at, don't insert the text.
+					// There must be enough space available after this position for sequence-interrupted.
 					blockBoundary = Optional.of(hasBlockInScope(x.getHead(), flowHeight));
 					if (!x.getTail().isEmpty() && blockBoundary.get()) {
 						// Find the best break point with the new limit
@@ -294,6 +390,12 @@ public class PageSequenceBuilder2 {
 					}
 				} else {
 					SplitPointCost<RowGroup> cost = (SplitPointDataSource<RowGroup, ?> units, int in, int limit)->{
+							// variableWidthCost > 0 means that there is space on the row taken up
+							// by header or footer fields and the RowGroup can not be fit into the
+							// available space (does not support variable width).
+							// We know that if this is the case the row is blank (RowGroupProvider
+							// inserts them) so it is fine to break here, but we give it a big
+							// penalty so that it might become preferable to break before the block.
 							double variableWidthCost = (reservedWidths.apply(in)>0 && !units.get(in).isMergeable())?10:0;
 							return (
 										(units.get(in).isBreakable()?1:2) + variableWidthCost
@@ -307,6 +409,7 @@ public class PageSequenceBuilder2 {
 					float flowHeight = current.getFlowHeight() - anyHeight - seqHeight;
 					spec = sph.find(flowHeight, copy, cost, force?StandardSplitOption.ALLOW_FORCE:null);
 				}
+				// The optimal break point is found. Now we do the actual split.
 				// Now apply the information to the live data
 				data.setAllowHyphenateLastLine(hyphenateLastLine);
 				SplitPoint<RowGroup, RowGroupDataSource> res = sph.split(spec, data);
@@ -318,12 +421,15 @@ public class PageSequenceBuilder2 {
 						throw new RuntimeException("A layout unit was too big for the page.");
 					}
 				}
+				// The supplements are added to the page area
 				for (RowGroup rg : res.getSupplements()) {
 					current.addToPageArea(rg.getRows());
 				}
 				force = res.getHead().size()==0;
 				data = res.getTail();
 				List<RowGroup> head;
+				// If there is a sequence-interrupted or sequence-resumed, it is added to the end of
+				// current page or the beginning of the next respectively.
 				if (addTransition && transitionContent.isPresent()) {
 					if (transitionContent.get().getType()==TransitionContent.Type.INTERRUPT) {
 						head = new ArrayList<>(res.getHead());
@@ -337,6 +443,7 @@ public class PageSequenceBuilder2 {
 				} else {
 					head = res.getHead();
 				}
+				// The same for any-interrupted and any-resumed.
 				//TODO: combine this if statement with the one above
 				if (!anyTransitionText.isEmpty()) {
 					switch (transitionContent.get().getType()) {
@@ -357,19 +464,35 @@ public class PageSequenceBuilder2 {
 					pcbl = cbl;
 					cbl = gr.getLineProperties().getBlockLineLocation();
 				}
+				// Add the body rows to the page.
 				addRows(head, current);
+				// The VolumeKeepPriority of the page is the maximum value (lowest priority) of all
+				// RowGroups. Discarded RowGroups (i.e. collapsed margins) are also taken into
+				// account.
 				current.setAvoidVolumeBreakAfter(getVolumeKeepPriority(res.getDiscarded(), getVolumeKeepPriority(res.getHead(), VolumeKeepPriority.empty())));
+				// Store info about this volume transition for use in the next iteration (used in SheetDataSource).
+				// No need to do this unless there is an active transition builder.
 				if (context.getTransitionBuilder().getProperties().getApplicationRange()!=ApplicationRange.NONE) {
-					// no need to do this, unless there is an active transition builder
+					// Determine whether there is a block boundary on the page, with enough space
+					// available after this point for sequence-interrupted and any-interrupted.
 					boolean hasBlockBoundary = blockBoundary.isPresent()?blockBoundary.get():res.getHead().stream().filter(r->r.isLastRowGroupInBlock()).findFirst().isPresent();
 					bc.getRefs().keepTransitionProperties(current.getDetails().getPageLocation(), new TransitionProperties(current.getAvoidVolumeBreakAfter(), hasBlockBoundary));
 				}
+				// Discard collapsed margins, but retain their properties (identifiers, markers,
+				// keep-with-next-sheets, keep-with-previous-sheets).
 				for (RowGroup rg : res.getDiscarded()) {
 					addProperties(current, rg);
 				}
+				// If the space needed for the footnotes exceeds max-height, we need to use the
+				// fallback. This will result in a RestartPaginationException, i.e. the pagination
+				// should be restarted from the beginning (start of current iteration).
 				if (hasPageAreaCollection() && current.pageAreaSpaceNeeded() > master.getPageArea().getMaxHeight()) {
 					reassignCollection();
 				}
+				// We are finished with the page if either the block was split (tail not empty), or
+				// if the next block has break-before="page" or break-before="sheet". In case of
+				// break-before="sheet" we insert an empty page if needed. If there is no next block
+				// we are also finished (the while loop will end).
 				if (!data.isEmpty()) {
 					return current;
 				} else if (current!=null && dataGroupsIndex<dataGroups.size()) {
@@ -453,8 +576,9 @@ public class PageSequenceBuilder2 {
 			if (context.getTransitionBuilder().getProperties().getApplicationRange()==ApplicationRange.NONE) {
 				return list.get(list.size()-1).getAvoidVolumeBreakAfterPriority();
 			} else {
-				// we want the highest value (lowest priority) to maximize the chance that this page is used
-				// when finding the break point
+				// We want the highest value (lowest priority) to maximize the chance that this page
+				// is used when finding the break point. An absent priority is "higher" than the
+				// lowest priority (9) is "higher" than the highest priority (1).
 				return list.stream().map(v->v.getAvoidVolumeBreakAfterPriority())
 						.max(VolumeKeepPriority::compare)
 						.orElse(VolumeKeepPriority.empty());
@@ -580,6 +704,16 @@ public class PageSequenceBuilder2 {
 		return getSizeLast(fromIndex);
 	}
 	
+	/**
+	 * Returns the number of supplied pages since <code>fromIndex</code> ({@link #getToIndex()} -
+	 * <code>fromIndex</code>), rounded to an even number if duplex, i.e. in the case of duplex it
+	 * represents twice the number of sheets needed to contain the supplied pages since
+	 * <code>fromIndex</code> (assuming that the first page after <code>fromIndex</code> starts on
+	 * the front side of the first sheet).
+	 *
+	 * @param fromIndex a page index
+	 * @return a number of pages
+	 */
 	public int getSizeLast(int fromIndex) {
 		int size = getToIndex()-fromIndex;
 		if (master.duplex() && (size % 2)==1) {
@@ -589,18 +723,32 @@ public class PageSequenceBuilder2 {
 		}
 	}
 	
+	/**
+	 * Returns the number of supplied pages.
+	 *
+	 * @return a number of pages
+	 */
 	public int size() {
 		return getToIndex()-fromIndex;
 	}
 
 	/**
-	 * Gets the index for the first item in this sequence, counting all preceding items in the document, zero-based. 
-	 * @return returns the first index
+	 * Returns the provided value of <code>pageOffset</code> in {@link #PageSequenceBuilder2(int,
+	 * LayoutMaster, int, BlockSequence, FormatterContext, DefaultContext, SequenceId,
+	 * BlockLineLocation)}.
+	 *
+	 * @return a page index
 	 */
 	public int getGlobalStartIndex() {
 		return fromIndex;
 	}
 
+	/**
+	 * Returns the index of the page that will be (or "would" be) supplied next, provided that
+	 * {@link #getGlobalStartIndex()} is the index of the first page minus 1.
+	 *
+	 * @return a page index
+	 */
 	public int getToIndex() {
 		return toIndex;
 	}

--- a/src/org/daisy/dotify/formatter/impl/page/PaginatorTools.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PaginatorTools.java
@@ -7,6 +7,9 @@ import java.util.TreeSet;
 
 import org.daisy.dotify.common.text.StringTools;
 
+/**
+ * Does positioning of header/footer fields, and layout of tables.
+ */
 class PaginatorTools {
 	/**
 	 * Distribution modes 

--- a/src/org/daisy/dotify/formatter/impl/page/PaginatorToolsException.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PaginatorToolsException.java
@@ -1,9 +1,17 @@
 package org.daisy.dotify.formatter.impl.page;
 
 /**
- * A LayoutToolsException is an exception that indicates 
- * conditions in a LayoutTools process that a reasonable 
- * application might want to catch.
+ * A PaginatorToolsException is an exception that indicates conditions in a PaginatorTools process
+ * that is intended to be propagated to the calling application and that a reasonable application
+ * might want to catch.
+ *
+ * <p>Examples:</p>
+ * <ul>
+ *   <li>Text does not fit within provided space (in header/footer)</li>
+ *   <li>Translation of resolved header/footer field failed</li>
+ *   <li>Text does not fit within cell (in table)</li>
+ * </ul>
+ *
  * @author Joel Håkansson
  */
 class PaginatorToolsException extends Exception {

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroup.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroup.java
@@ -13,6 +13,11 @@ import org.daisy.dotify.formatter.impl.row.LineProperties;
 import org.daisy.dotify.formatter.impl.row.RowImpl;
 import org.daisy.dotify.formatter.impl.search.VolumeKeepPriority;
 
+/**
+ * <code>RowGroup</code> is the unit used when calculating page breaks. For this reason,
+ * <code>RowGroup</code> implements {@link SplitPointUnit}. It contains zero, one or more rows that
+ * can not be separated.
+ */
 class RowGroup implements SplitPointUnit {
 	private final List<RowImpl> rows;
 	private final List<Marker> markers;
@@ -187,21 +192,33 @@ class RowGroup implements SplitPointUnit {
 		return Collections.unmodifiableList(rows);
 	}
 
+	/**
+	 * Means that the page can be broken after this RowGroup.
+	 */
 	@Override
 	public boolean isBreakable() {
 		return breakable;
 	}
 
+	/**
+	 * Means that this RowGroup can be skipped if a page break follows (e.g. bottom margins).
+	 */
 	@Override
 	public boolean isSkippable() {
 		return skippable;
 	}
 
+	/**
+	 * Means that this RowGroup may be combined with preceding RowGroups (e.g. adjoining margins).
+	 */
 	@Override
 	public boolean isCollapsible() {
 		return collapsible;
 	}
 
+	/**
+	 * <code>1</code> means <a href="http://braillespecs.github.io/pef/images/rendering.jpg">dot-to-dot height</a>.
+	 */
 	@Override
 	public float getUnitSize() {
 		return unitSize;

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroupDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroupDataSource.java
@@ -20,11 +20,21 @@ import org.daisy.dotify.formatter.impl.row.LineProperties;
 import org.daisy.dotify.formatter.impl.search.BlockLineLocation;
 
 /**
- * <p>Provides a data source for row groups.</p>
- * 
+ * <p>Provides a {@link SplitPointDataSource data source} for {@link RowGroup row groups}.</p>
+ *
+ * <p>The input is</p>
+ * <ul>
+ *   <li>a {@link RowGroupSequence}, i.e. a sequence of {@link Block}s starting at a hard page
+ *       break (<code>break-before="page"</code> or <code>break-before="sheet"</code>) or a block
+ *       with absolute positioning (<code>vertical-position</code>)</li>
+ *   <li>a {@link Supplements} of {@link RowGroup}s: a map containing the items in the collection
+ *       corresponding to the page's <code>page-area</code> (if any). Each item is a single RowGroup.</li>
+ * </ul>
+ *
  * <p>Note that the implementation requires that break point searching is performed on a copy,
  * so that the items are created when a split is performed. If this assumption is not met,
  * things will break.</p>
+ *
  * @author Joel Håkansson
  */
 class RowGroupDataSource implements SplitPointDataSource<RowGroup, RowGroupDataSource> {
@@ -184,6 +194,7 @@ class RowGroupDataSource implements SplitPointDataSource<RowGroup, RowGroupDataS
 		return true;
 	}
 
+	// this happens when a new page is started
 	@Override
 	public SplitResult<RowGroup, RowGroupDataSource> splitInRange(int atIndex) {
 		// TODO: rewrite this so that rendered tail data is discarded

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroupProvider.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroupProvider.java
@@ -16,6 +16,24 @@ import org.daisy.dotify.formatter.impl.search.CrossReferenceHandler;
 import org.daisy.dotify.formatter.impl.search.DefaultContext;
 import org.daisy.dotify.formatter.impl.search.VolumeKeepPriority;
 
+/**
+ * Used by {@link RowGroupDataSource} to generate {@link RowGroup}s from a {@link Block}.
+ *
+ * <p>The input is a {@link Block} (and its corresponding {@link AbstractBlockContentManager}).</p>
+ *
+ * <p>The {@link RowGroup.Builder#avoidVolumeBreakAfterPriority(VolumeKeepPriority)
+ * avoidVolumeBreakAfterPriority} of the {@link RowGroup}s are set to the {@link
+ * Block#getAvoidVolumeBreakInsidePriority() getAvoidVolumeBreakInsidePriority} or {@link
+ * Block#getAvoidVolumeBreakAfterPriority() getAvoidVolumeBreakAfterPriority} of the {@link Block},
+ * depending on whether a RowGroup follows or not.</p>
+ *
+ * <p>Group markers, group anchors and group identifiers are added to the
+ * first content RowGroup (content = not padding, margin or border).</p>
+ *
+ * <p>An empty RowGroup is produced if the block contains markers, anchors or identifiers but no
+ * significant content (significant content = content that results in an actual line, i.e. non-empty
+ * text, a non-empty evaluate, a br, a page-number, a leader).</p>
+ */
 class RowGroupProvider {
 	private final LayoutMaster master;
 	private final Block g;
@@ -102,6 +120,8 @@ class RowGroupProvider {
 	}
 
 	private RowGroup nextInner(LineProperties lineProps) {
+		// if the block does not support variable width (e.g. when there are left or right borders)
+		// and header or footer fields are present on the line, insert an empty row
 		if (lineProps.getReservedWidth()>0 && !bcm.supportsVariableWidth()) {
 			return new RowGroup.Builder(master.getRowSpacing()).add(new RowImpl())
 					.mergeable(false)

--- a/src/org/daisy/dotify/formatter/impl/page/RowGroupSequence.java
+++ b/src/org/daisy/dotify/formatter/impl/page/RowGroupSequence.java
@@ -6,6 +6,11 @@ import java.util.List;
 import org.daisy.dotify.api.formatter.FormattingTypes.BreakBefore;
 import org.daisy.dotify.formatter.impl.core.Block;
 
+/**
+ * Sequence of {@link Block}s starting at a hard page break (<code>break-before="page"</code> or
+ * <code>break-before="sheet"</code>) or a block with absolute positioning
+ * (<code>vertical-position</code>).
+ */
 class RowGroupSequence {
 	private final List<Block> blocks;
 	private final BreakBefore breakBefore;

--- a/src/org/daisy/dotify/formatter/impl/page/VerticalSpacing.java
+++ b/src/org/daisy/dotify/formatter/impl/page/VerticalSpacing.java
@@ -5,6 +5,14 @@ import java.util.Objects;
 import org.daisy.dotify.api.formatter.BlockPosition;
 import org.daisy.dotify.formatter.impl.row.RowImpl;
 
+/**
+ * A wrapper around a {@link BlockPosition}, i.e. a combination of a <code>vertical-position</code>
+ * and a <code>vertical-align</code>, to specify a vertical position of a block on a page.
+ *
+ * <p>{@link #getEmptyRow()} is for inserting padding before the block. The height (row spacing) of
+ * the returned {@link RowImpl} should be (or is assumed to be) equal to the row spacing of the
+ * current <code>layout-master</code> (which is also the unit for <code>vertical-position</code>).
+ */
 class VerticalSpacing {
 	private final BlockPosition pos;
 	private final RowImpl emptyRow;

--- a/src/org/daisy/dotify/formatter/impl/page/package-info.java
+++ b/src/org/daisy/dotify/formatter/impl/page/package-info.java
@@ -1,6 +1,8 @@
 /**
- * <p>This package is responsible for laying out a block sequence into pages.
- * The main class is {@link org.daisy.dotify.formatter.impl.page.PageSequenceBuilder2}.</p>
+ * <p>Provides functionality for laying out a {@link BlockSequence} into {@link
+ * org.daisy.dotify.formatter.impl.common.Page}s.</p>
+ *
+ * <p>The main class is {@link org.daisy.dotify.formatter.impl.page.PageSequenceBuilder2}.</p>
  *
  * <p>Uses the {@link org.daisy.dotify.formatter.impl.row} package to layout blocks into rows.</p>
  * 

--- a/src/org/daisy/dotify/formatter/impl/row/RowInfo.java
+++ b/src/org/daisy/dotify/formatter/impl/row/RowInfo.java
@@ -6,11 +6,19 @@ class RowInfo {
 	private final String preContent;
 	private final int available;
 
+	/**
+	 * @param preContent The content
+	 * @param available The total space available on a row for content and left margin.
+	 */
 	RowInfo(String preContent, int available) {
 		this.preContent = preContent;
 		this.available = available;
 	}
 
+	/**
+	 * @param r a row
+	 * @return the space available on the row for additional content.
+	 */
 	int getMaxLength(RowImpl.Builder r) {
 		int preContentPos = r.getLeftMargin().getContent().length()+StringTools.length(preContent);
 		int maxLenText = available-(preContentPos);

--- a/src/org/daisy/dotify/formatter/impl/row/package-info.java
+++ b/src/org/daisy/dotify/formatter/impl/row/package-info.java
@@ -1,6 +1,8 @@
 /**
- * <p>Provides functionality for line breaking a block of text.
- * The main class is {@link org.daisy.dotify.formatter.impl.row.BlockContentManager}.</p>
+ * <p>Provides functionality for line breaking a block of text.</p>
+ *
+ * <p>The main class is {@link org.daisy.dotify.formatter.impl.row.BlockContentManager}.</p>
+ *
  * <p><b>IMPORTANT: This package is part of the FormatterFactory implementation 
  * in {@link org.daisy.dotify.formatter.impl}. Classes in this package 
  * should only be used by this implementation.</b></p>

--- a/src/org/daisy/dotify/formatter/impl/search/AnchorData.java
+++ b/src/org/daisy/dotify/formatter/impl/search/AnchorData.java
@@ -2,6 +2,11 @@ package org.daisy.dotify.formatter.impl.search;
 
 import java.util.List;
 
+/**
+ * Keeps track of the <a
+ * href="http://braillespecs.github.io/obfl/obfl-specification.html#L924">anchors</a> contained on a
+ * page.
+ */
 public class AnchorData {
 	private final int pageNumber;
 	private final List<String> refs;

--- a/src/org/daisy/dotify/formatter/impl/search/BlockLineLocation.java
+++ b/src/org/daisy/dotify/formatter/impl/search/BlockLineLocation.java
@@ -1,5 +1,9 @@
 package org.daisy.dotify.formatter.impl.search;
 
+/**
+ * Precise location in the content, consisting of a {@link BlockAddress} which identifies the block,
+ * and a line number which indicates the line within that block (0-based).
+ */
 public final class BlockLineLocation {
 	private final BlockAddress blockAddress;
 	private final int lineNumber;

--- a/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
+++ b/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
@@ -4,9 +4,12 @@ import java.util.NoSuchElementException;
 
 /**
  * <p>Provides a simple data type for volume keep priority, where 1 represents the highest priority
- * and 9 the lowest. This class is modeled on Java's Optional and provides similar
- * capabilities. As with Optional, setting a field with this type to null is strongly
- * discouraged. Instead, use {@link #empty()} to create an empty instance.</p>
+ * and 9 the lowest. A high priority means that we do more effort to avoid splitting a volume within
+ * the area the priority is declared on.</p>
+ *
+ * <p>This class is modeled on Java's Optional and provides similar capabilities. As with Optional,
+ * setting a field with this type to null is strongly discouraged. Instead, use {@link #empty()} to
+ * create an empty instance.</p>
  * 
  * <p>The primary reason for creating a special class is to make the meaning of the 
  * number contained in it clearer. But in addition, it makes it possible to enforce 
@@ -89,8 +92,6 @@ public final class VolumeKeepPriority {
 	 * <p>Compares the specified values.</p>
 	 * <p>Note that, because a higher priority is represented by a lower value,
 	 * this function may appear to be incorrect in some contexts.</p>
-	 * <p>An absent priority is "higher" than the lowest priority ({@code 9}) is "higher" than the
-	 * highest priority ({@code 1}).</p>
 	 * @param p1 the first value
 	 * @param p2 the second value
 	 * @return the value {@code 0} if the priority of {@code p1} is

--- a/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
+++ b/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
@@ -89,6 +89,8 @@ public final class VolumeKeepPriority {
 	 * <p>Compares the specified values.</p>
 	 * <p>Note that, because a higher priority is represented by a lower value,
 	 * this function may appear to be incorrect in some contexts.</p>
+	 * <p>An absent priority is "higher" than the lowest priority ({@code 9}) is "higher" than the
+	 * highest priority ({@code 1}).</p>
 	 * @param p1 the first value
 	 * @param p2 the second value
 	 * @return the value {@code 0} if the priority of {@code p1} is

--- a/src/org/daisy/dotify/formatter/impl/sheet/EvenSizeVolumeSplitter.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/EvenSizeVolumeSplitter.java
@@ -9,15 +9,17 @@ import java.util.logging.Logger;
  *
  * <p>Each {@link SheetGroup volume group} has its own <code>VolumeSplitter</code> instance.</p>
  *
- * <p>The target sizes of the volumes are computed in {@link
- * EvenSizeVolumeSplitterCalculator}. Extra volumes are added based on the information provided
- * through {@link #updateSheetCount(int, int) updateSheetCount}:</p>
+ * <p>The target sizes of the volumes are computed in {@link EvenSizeVolumeSplitterCalculator} based
+ * on a total number of sheets and a <code>volumeOffset</code> parameter. By increasing this
+ * parameter, extra volumes are added on top of the number strictly needed to accommodate all the
+ * sheets, and the volume sizes are decreased. Different configurations are tried and evaluated
+ * based on information about the previous iterations, provided through {@link
+ * #updateSheetCount(int, int) updateSheetCount}:</p>
  *
  * <ul>
- *   <li>the actual total number of sheets in the volume group. "Actual" means in the previous
- *       iteration. "Total" means including remaining sheets and sheets coming from the pre- and
- *       post-content.</li>
- *   <li>the number of sheets that did not fit in the volume group (in the previous iteration)</li>
+ *   <li>The actual total number of sheets in the volume group. "Total" means including remaining
+ *       sheets and sheets coming from the pre- and post-content.</li>
+ *   <li>The number of sheets that did not fit in the volume group.</li>
  * </ul>
  *
  * <p>The actual sizes of the volumes are not determined here. This is done in {@link
@@ -27,7 +29,7 @@ class EvenSizeVolumeSplitter implements VolumeSplitter {
 	private static final Logger logger = Logger.getLogger(EvenSizeVolumeSplitter.class.getCanonicalName());
 	private EvenSizeVolumeSplitterCalculator sdc;
 	private final SplitterLimit splitterMax;
-	// number of volumes to add on top of the number of volumes strictly required to contain the
+	// number of volumes to add on top of the number of volumes strictly needed to accommodate the
 	// total number of sheets
 	int volumeOffset = 0;
 	

--- a/src/org/daisy/dotify/formatter/impl/sheet/PageCounter.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/PageCounter.java
@@ -2,7 +2,7 @@ package org.daisy.dotify.formatter.impl.sheet;
 
 /**
  * Provides state needed for a text flow.
- * 
+ *
  * @author Joel Håkansson
  */
 public class PageCounter {
@@ -23,20 +23,35 @@ public class PageCounter {
 		pageOffset = value;
 	}
 
+	/**
+	 * Page number counter. Represents the current value of the default "<a
+	 * href="http://braillespecs.github.io/obfl/obfl-specification.html#pagenumbercounter"
+	 * ><code>page-number-counter</code></a>" (i.e. the value for the page that was produced
+	 * last).
+	 *
+	 * <p>Initially <code>0</code>, or the value specified with <code>initial-page-number</code>
+	 * minus 1.</p>
+	 *
+	 * @return the counter value
+	 */
 	public int getDefaultPageOffset() {
 		return pageOffset;
 	}
 
 	/**
-	 * This is used for searching and MUST be continuous. Do not use for page numbers.
-	 * @return returns the page count
+	 * Simple page counter. Represents the number of pages currently produced. This is used for
+	 * searching and MUST be continuous. Do not use for page numbers.
+	 *
+	 * <p>Initially <code>0</code>.</p>
+	 *
+	 * @return the counter value
 	 */
 	public int getPageCount() {
 		return pageCount;
 	}
 	
 	/**
-	 * Advance to the next page.
+	 * Advance to the next page. Increments the value of {@link #getPageCount()} by <code>1</code>.
 	 */
 	public void increasePageCount() {
 		pageCount++;

--- a/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
@@ -272,10 +272,10 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
 						transition = context.getTransitionBuilder().getResumeTransition();
 					}
 				}
-				boolean hyphenateLastLine = 
-						!(	!context.getConfiguration().allowsEndingVolumeOnHyphen() 
-								&& sheetBuffer.size()==index-1 
-								&& (!sectionProperties.duplex() || pageIndex % 2 == 1));
+				boolean hyphenateLastLine =
+					context.getConfiguration().allowsEndingVolumeOnHyphen()
+					|| sheetBuffer.size() != index-1
+					|| (sectionProperties.duplex() && pageIndex % 2 == 0);
 				
 				PageImpl p = psb.nextPage(initialPageOffset, hyphenateLastLine, Optional.ofNullable(transition), wasSplitInsideSequence, isFirst);
 				pageCounter.increasePageCount();

--- a/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/SheetDataSource.java
@@ -28,9 +28,22 @@ import org.daisy.dotify.formatter.impl.search.TransitionProperties;
 import org.daisy.dotify.formatter.impl.search.VolumeKeepPriority;
 
 /**
- * Provides a data source for sheets. Given a list of 
- * BlockSequences, sheets are produced one by one.
- * 
+ * Provides a data source for {@link Sheet}s. Given a list of {@link BlockSequence}s, sheets are
+ * produced one by one.
+ *
+ * <p>The input is:</p>
+ * <ul>
+ *   <li>The list of {@link BlockSequence}s contained in a volume group or in the pre- or post-content
+ *       of a volume. A volume group is a set of block sequences starting with a hard volume break
+ *       (<code>break-before="volume"</code>).</li>
+ *   <li>A {@link PageCounter}</li>
+ *   <li>The index of the volume group (0-based) or null if the input comes from pre- or post-content.</li>
+ * </ul>
+ *
+ * <p>The computed {@link VolumeKeepPriority} of a sheet is the priority of the back side page, or
+ * the priority of the front side page if that value is higher (lower priority) and if
+ * <code>&lt;volume-transition range="sheet"/&gt;</code>.</p>
+ *
  * @author Joel Håkansson
  */
 public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSource> {
@@ -177,12 +190,14 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
 		Sheet.Builder s = null;
 		SheetIdentity si = null;
 		while (index<0 || sheetBuffer.size()<index) {
+			// this happens when a new volume is started
 			if (updateCounter) { 
 				if(counter!=null) {
 					initialPageOffset = rcontext.getRefs().getPageNumberOffset(counter) - psb.size();
 				} else {
 					initialPageOffset = pageCounter.getDefaultPageOffset() - psb.size();
 				}
+				// psbCurStartIndex (index of first page of current psb in current volume) is changed because we started a new volume
 				psbCurStartIndex = psb.getToIndex();
 				updateCounter = false;
 			}
@@ -272,6 +287,10 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
 						transition = context.getTransitionBuilder().getResumeTransition();
 					}
 				}
+				// The last line may be hyphenated when
+				// - the configuration allows it, or
+				// - we are not on the last sheet of the volume, or
+				// - we are in duplex mode and the current page index is even (so we're not on the last page of the sheet)
 				boolean hyphenateLastLine =
 					context.getConfiguration().allowsEndingVolumeOnHyphen()
 					|| sheetBuffer.size() != index-1
@@ -315,7 +334,12 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
 				if (!psb.hasNext()) {
 					rcontext.getRefs().setSequenceScope(seqId, psb.getGlobalStartIndex(), psb.getToIndex());
 				}
-				int lastPageNumber = initialPageOffset + psbCurStartIndex - psb.getGlobalStartIndex() + psb.getSizeLast(psbCurStartIndex);
+				// page number of the last page returned by psb
+				int lastPageNumber =
+					initialPageOffset                    // page number corresponding to the first page returned by psb, minus 1
+					+ psbCurStartIndex                   // index of first page of psb in current volume
+					- psb.getGlobalStartIndex()          // value of psbCurStartIndex when psb was created
+					+ psb.getSizeLast(psbCurStartIndex); // number of supplied pages since psbCurStartIndex, rounded to an even number if duplex
 				if (counter!=null) {
 					rcontext.getRefs().setPageNumberOffset(counter, lastPageNumber);
 				} else {
@@ -345,6 +369,7 @@ public class SheetDataSource implements SplitPointDataSource<Sheet, SheetDataSou
 		return SplitPointDataSource.super.split(atIndex);
 	}
 
+	// this happens when a new volume is started
 	@Override
 	public SplitResult<Sheet, SheetDataSource> splitInRange(int atIndex) {
 		if (!ensureBuffer(atIndex)) {

--- a/src/org/daisy/dotify/formatter/impl/sheet/SheetGroupManager.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/SheetGroupManager.java
@@ -6,6 +6,8 @@ import java.util.List;
 /**
  * <p>Provides a manager for {@link SheetGroup}.</p>
  *
+ * <p>An {@link EvenSizeVolumeSplitter} is associated with every <code>SheetGroup</code>.</p>
+ *
  * <p>Used by {@link org.daisy.dotify.formatter.impl.VolumeProvider}.</p>
  *
  * @author Joel Håkansson

--- a/src/org/daisy/dotify/formatter/impl/sheet/VolumeSplitter.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/VolumeSplitter.java
@@ -1,7 +1,9 @@
 package org.daisy.dotify.formatter.impl.sheet;
 
 /**
- * Provides a volume splitter.
+ * Allocates a number of volumes required to accomodate the sheets, and determines the target
+ * (i.e. optimal) number of sheets for each volume. The maximum number of sheets for each volume is
+ * determined by a {@link SplitterLimit}.
  * 
  * @author Joel Håkansson
  *
@@ -18,8 +20,8 @@ public interface VolumeSplitter {
 	void updateSheetCount(int sheets, int sheetsRemaining);
 
 	/**
-	 * Gets the number of sheets in a volume.
-	 * 
+	 * Gets the target number of sheets in a volume.
+	 *
 	 * @param volIndex volume index, one-based
 	 * @return returns the number of sheets in the volume
 	 */

--- a/src/org/daisy/dotify/formatter/impl/sheet/package-info.java
+++ b/src/org/daisy/dotify/formatter/impl/sheet/package-info.java
@@ -1,12 +1,14 @@
 /**
- * <p>This package is responsible for laying out block sequences into sheets.
- * It also contains classes related to volume breaking.
- * The main class is {@link org.daisy.dotify.formatter.impl.sheet.SheetDataSource}.
- * </p>
+ * <p>Provides functionality for laying out {@link
+ * org.daisy.dotify.formatter.impl.page.BlockSequence}s into {@link Sheet}s.</p>
  *
- * <p>Uses the {@link org.daisy.dotify.formatter.impl.page}
- * package to layout a block sequence into pages.</p>
- * 
+ * <p>The main class is {@link org.daisy.dotify.formatter.impl.sheet.SheetDataSource}. Uses the
+ * {@link org.daisy.dotify.formatter.impl.page} package to layout a {@link
+ * org.daisy.dotify.formatter.impl.page.BlockSequence} into {@link
+ * org.daisy.dotify.formatter.impl.common.Page}s.</p>
+ *
+ * <p>Also contains some classes related to volume breaking.</p>
+ *
  * <p><b>IMPORTANT: This package is part of the FormatterFactory implementation 
  * in {@link org.daisy.dotify.formatter.impl}. Classes in this package 
  * should only be used by this implementation.</b></p>

--- a/src/org/daisy/dotify/formatter/impl/writer/package-info.java
+++ b/src/org/daisy/dotify/formatter/impl/writer/package-info.java
@@ -2,7 +2,10 @@
  * <p>
  * Provides {@link org.daisy.dotify.api.writer.PagedMediaWriterFactoryService} implementations.
  * </p>
- * 
+ *
+ * <p>The main classes are {@link PEFMediaWriterFactoryService} and {@link
+ * TextMediaWriterFactoryService}.</p>
+ *
  * <p>
  * Note on adding PagedMediaWriter implementations: First consider if your needs
  * can be met by converting a PEF file to your desired format using (or


### PR DESCRIPTION
This contains all the changes I did in https://github.com/brailleapps/dotify.formatter.impl/pull/102, with some improvements, and one or two changes from Paul are also included.

The improvements compared with https://github.com/brailleapps/dotify.formatter.impl/pull/102 are:

- I changed all the occurences of "used by X" in class Y by "uses Y" in class X. Joel made a remark about that last time.
- I improved the overview page to make it easier to navigate to certain parts of the code.
- I fixed my remaining TODOs.
- I answered some more of Paul's questions.
- Some other additions and rewordings.

@kalaspuffar, @PaulRambags and @joeha480 What do you think? Is this OK to merge? We're still a long way from a full coverage, and things can be expanded and worded differently, but I think this is already a major improvement. We can further improve the documentation of specific parts of the code as we work on that code. 

The remaining questions from Paul in https://github.com/brailleapps/dotify.formatter.impl/pull/102 (which is not much anymore) can be discussed and handled in a subsequent PR.