### PR TITLE
Revert the meaning of KeepVolumePriority.compare() to make in more intuitive

### DIFF
--- a/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
+++ b/src/org/daisy/dotify/formatter/impl/page/PageSequenceBuilder2.java
@@ -577,11 +577,10 @@ public class PageSequenceBuilder2 {
 			if (context.getTransitionBuilder().getProperties().getApplicationRange()==ApplicationRange.NONE) {
 				return list.get(list.size()-1).getAvoidVolumeBreakAfterPriority();
 			} else {
-				// We want the highest value (lowest priority) to maximize the chance that this page
-				// is used when finding the break point. An absent priority is "higher" than the
-				// lowest priority (9) is "higher" than the highest priority (1).
+				// We want the lowest priority to maximize the chance that this page is used when
+				// finding the break point.
 				return list.stream().map(v->v.getAvoidVolumeBreakAfterPriority())
-						.max(VolumeKeepPriority::compare)
+						.min(VolumeKeepPriority.naturalOrder())
 						.orElse(VolumeKeepPriority.empty());
 			}
 		} else {

--- a/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
+++ b/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
@@ -1,5 +1,6 @@
 package org.daisy.dotify.formatter.impl.search;
 
+import java.util.Comparator;
 import java.util.NoSuchElementException;
 
 /**
@@ -18,7 +19,8 @@ import java.util.NoSuchElementException;
  * 
  * @author Joel Håkansson
  */
-public final class VolumeKeepPriority {
+public final class VolumeKeepPriority implements Comparable<VolumeKeepPriority> {
+
 	// For performance reasons, -1 is used to represent the empty object
 	private static final VolumeKeepPriority EMPTY = new VolumeKeepPriority(-1);
 	private final int value;
@@ -33,8 +35,8 @@ public final class VolumeKeepPriority {
 	 * @return returns a new instance
 	 */
 	public static VolumeKeepPriority of(int value) {
-		if (value<1 || value>=10) {
-			throw new IllegalArgumentException("Value out of range [1, 10): " + value);
+		if (value<1 || value>9) {
+			throw new IllegalArgumentException("Value out of range [1, 9]: " + value);
 		}
 		return new VolumeKeepPriority(value);
 	}
@@ -57,9 +59,8 @@ public final class VolumeKeepPriority {
 	}
 	
 	/**
-	 * Gets the priority, if present. The value is in the range
-	 * [1, 10) where 1 represents the highest priority and 9 the
-	 * lowest.
+	 * Gets the priority value, if present. The value is in the range
+	 * [1, 9] where 1 represents the highest priority and 9 the lowest.
 	 * @return returns the priority
 	 * @throws NoSuchElementException if no priority is set.
 	 */
@@ -89,25 +90,42 @@ public final class VolumeKeepPriority {
 	}
 
 	/**
-	 * <p>Compares the specified values.</p>
-	 * <p>Note that, because a higher priority is represented by a lower value,
-	 * this function may appear to be incorrect in some contexts.</p>
-	 * @param p1 the first value
-	 * @param p2 the second value
-	 * @return the value {@code 0} if the priority of {@code p1} is
-	 *			equal to {@code p2}; a value less than
-	 *			{@code 0} if the priority of {@code p1} is less than
-	 *			the priority of {@code p2}; and a value greater than {@code 0}
-	 *			if the priority of {@code p1} is greater than
-	 *			the priority of {@code p2}; if {@code p1} does not have 
-	 * 			a priority value and {@code p2} does, a value greater than {@code 0}
-	 * 			is returned; if {@code p1} has a priority value and {@code p2} does not,
-	 * 			a value less than {@code 0} is returned; if neither {@code p1} 
-	 * 			nor {@code p2} has a priority value, the value {@code 0} is returned.
+	 * <p>Compares this priority with the specified priority.</p>
+	 *
+	 * <p>Returns a negative integer, zero, or a positive integer as this priority is lower, equal
+	 * to, or higher than the specified priority. An {@link #empty() absent} priority is considered
+	 * lower than the lowest priority.</p>
+	 *
+	 * <p>Note that this method does not compare the <em>integer values</em> returned by {@link
+	 * #getValue()}, but rather represents the "natural" ordering. (The fact that a higher priority
+	 * is represented by a lower integer value may cause some confusion in this regard.)</p>
+	 *
+	 * @param o The other priority
+	 * @return The value {@code 0} if the priority of {@code this} is equal to {@code o}; a value
+	 *			less than {@code 0} if the priority of {@code this} is lower than the priority of
+	 *			{@code o}; and a value greater than {@code 0} if the priority of {@code this} is
+	 *			greater than the priority of {@code o}; if {@code this} does not have a priority
+	 *			value and {@code o} does, a value greater than {@code 0} is returned; if {@code
+	 *			this} has a priority value and {@code o} does not, a value less than {@code 0} is
+	 *			returned; if neither {@code this} nor {@code o} has a priority value, the value
+	 *			{@code 0} is returned.
 	 */
-	public static int compare(VolumeKeepPriority p1, VolumeKeepPriority p2) {
-		return Integer.compare(p1.orElse(10), p2.orElse(10));
+	public int compareTo(VolumeKeepPriority o) {
+		return Integer.compare(o.orElse(10), this.orElse(10));
 	}
+
+	/**
+	 * <p>Returns a comparator that imposes the natural ordering on {@link VolumeKeepPriority} objects.</p>
+	 *
+	 * <p>Objects are ordered according to {@link #compareTo(VolumeKeepPriority)}, from lower to higher priority.</p>
+	 */
+	public static Comparator<VolumeKeepPriority> naturalOrder() {
+		if (comparator == null)
+			comparator = Comparator.<VolumeKeepPriority>naturalOrder();
+		return comparator;
+	}
+
+	private static Comparator<VolumeKeepPriority> comparator = null;
 
 	@Override
 	public int hashCode() {

--- a/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
+++ b/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
@@ -120,8 +120,9 @@ public final class VolumeKeepPriority implements Comparable<VolumeKeepPriority> 
 	 * <p>Objects are ordered according to {@link #compareTo(VolumeKeepPriority)}, from lower to higher priority.</p>
 	 */
 	public static Comparator<VolumeKeepPriority> naturalOrder() {
-		if (comparator == null)
+		if (comparator == null) {
 			comparator = Comparator.<VolumeKeepPriority>naturalOrder();
+		}
 		return comparator;
 	}
 

--- a/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
+++ b/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
@@ -118,6 +118,9 @@ public final class VolumeKeepPriority implements Comparable<VolumeKeepPriority> 
 	 * <p>Returns a comparator that imposes the natural ordering on {@link VolumeKeepPriority} objects.</p>
 	 *
 	 * <p>Objects are ordered according to {@link #compareTo(VolumeKeepPriority)}, from lower to higher priority.</p>
+	 *
+	 * @return a negative integer, zero, or a positive integer as the first argument is less
+	 *         than, equal to, or greater than the second.
 	 */
 	public static Comparator<VolumeKeepPriority> naturalOrder() {
 		if (comparator == null) {

--- a/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
+++ b/src/org/daisy/dotify/formatter/impl/search/VolumeKeepPriority.java
@@ -119,8 +119,7 @@ public final class VolumeKeepPriority implements Comparable<VolumeKeepPriority> 
 	 *
 	 * <p>Objects are ordered according to {@link #compareTo(VolumeKeepPriority)}, from lower to higher priority.</p>
 	 *
-	 * @return a negative integer, zero, or a positive integer as the first argument is less
-	 *         than, equal to, or greater than the second.
+	 * @return a comparator that imposes the natural ordering on {@link VolumeKeepPriority} objects.
 	 */
 	public static Comparator<VolumeKeepPriority> naturalOrder() {
 		if (comparator == null) {

--- a/test/org/daisy/dotify/formatter/impl/search/VolumeKeepPriorityTest.java
+++ b/test/org/daisy/dotify/formatter/impl/search/VolumeKeepPriorityTest.java
@@ -1,6 +1,7 @@
 package org.daisy.dotify.formatter.impl.search;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -30,39 +31,31 @@ public class VolumeKeepPriorityTest {
 
 	@Test
 	public void testCompare_01() {
-		// This appears counter-intuitive because the *priority* of the first argument is lower, 
-		// but the value is in fact higher.
-		assertEquals(1, VolumeKeepPriority.compare(VolumeKeepPriority.empty(), VolumeKeepPriority.of(9)));
+		assertTrue(VolumeKeepPriority.naturalOrder().compare(VolumeKeepPriority.empty(), VolumeKeepPriority.of(9)) < 0);
 	}
 	
 	@Test
 	public void testCompare_02() {
-		// This appears counter-intuitive because the *priority* of the first argument is lower, 
-		// but the value is higher.
-		assertEquals(1, VolumeKeepPriority.compare(VolumeKeepPriority.of(9), VolumeKeepPriority.of(3)));
+		assertTrue(VolumeKeepPriority.naturalOrder().compare(VolumeKeepPriority.of(9), VolumeKeepPriority.of(3)) < 0);
 	}
 	
 	@Test
 	public void testCompare_03() {
-		// This appears counter-intuitive because the *priority* of the first argument is higher, 
-		// but the value is in fact lower.
-		assertEquals(-1, VolumeKeepPriority.compare(VolumeKeepPriority.of(9), VolumeKeepPriority.empty()));
+		assertTrue(VolumeKeepPriority.naturalOrder().compare(VolumeKeepPriority.of(9), VolumeKeepPriority.empty()) > 0);
 	}
 	
 	@Test
 	public void testCompare_04() {
-		// This appears counter-intuitive because the *priority* of the first argument is higher, 
-		// but the value is lower. 
-		assertEquals(-1, VolumeKeepPriority.compare(VolumeKeepPriority.of(1), VolumeKeepPriority.of(9)));
+		assertTrue(VolumeKeepPriority.naturalOrder().compare(VolumeKeepPriority.of(1), VolumeKeepPriority.of(9)) > 0);
 	}
 	
 	@Test
 	public void testCompare_05() {
-		assertEquals(0, VolumeKeepPriority.compare(VolumeKeepPriority.of(4), VolumeKeepPriority.of(4)));
+		assertEquals(0, VolumeKeepPriority.naturalOrder().compare(VolumeKeepPriority.of(4), VolumeKeepPriority.of(4)));
 	}
 	
 	@Test
 	public void testCompare_06() {
-		assertEquals(0, VolumeKeepPriority.compare(VolumeKeepPriority.empty(), VolumeKeepPriority.empty()));
+		assertEquals(0, VolumeKeepPriority.naturalOrder().compare(VolumeKeepPriority.empty(), VolumeKeepPriority.empty()));
 	}
 }


### PR DESCRIPTION
@PaulRambags @kalaspuffar The promised patch.